### PR TITLE
feat(synapto): release v0.1.0 preparation — uvx support, changelog, release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,6 @@ jobs:
         if: steps.check.outputs.require-result != 'true'
         run: |
           echo "error: only repo admins can create releases"
-          echo "actor: ${{ github.triggering_actor }}"
           exit 1
 
       - uses: actions/checkout@v4
@@ -41,13 +40,14 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: install uv
+        uses: astral-sh/setup-uv@v6
+
       - name: set up python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
+        run: uv python install 3.13
 
       - name: install build tools
-        run: pip install build tomli tomli-w
+        run: uv sync --extra dev --python 3.13
 
       - name: bump version
         id: bump
@@ -57,7 +57,6 @@ jobs:
 
           bump_type = "${{ inputs.bump_type }}"
 
-          # read current version from pyproject.toml
           with open("pyproject.toml", "rb") as f:
               data = tomli.load(f)
 
@@ -94,7 +93,7 @@ jobs:
           PYEOF
 
       - name: build package
-        run: python -m build
+        run: uv run python -m build
 
       - name: commit version bump
         run: |
@@ -113,5 +112,19 @@ jobs:
         with:
           tag_name: "v${{ steps.bump.outputs.version }}"
           name: "v${{ steps.bump.outputs.version }}"
-          generate_release_notes: true
+          body: |
+            ## what's changed
+
+            see [CHANGELOG.md](https://github.com/ramonlimaramos/synapto/blob/main/CHANGELOG.md) for details.
+
+            ### install / upgrade
+
+            ```bash
+            pip install synapto==${{ steps.bump.outputs.version }}
+            ```
+
+            or with auto-updates (recommended):
+            ```json
+            { "command": "uvx", "args": ["synapto", "serve"] }
+            ```
           files: dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to Synapto will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [0.1.0] - 2026-04-13
+
+### Added
+
+- **MCP server** with 10 tools: remember, recall, relate, forget, trust_feedback, find_contradictions, graph_query, list_entities, memory_stats, maintain
+- **3-way hybrid search** combining vector similarity (pgvector HNSW), full-text (tsvector + BM25), and HRR compositional algebra via Reciprocal Rank Fusion
+- **holographic reduced representations (HRR)** for compositional memory queries — probe, reason, and contradict operations that no vector database can do
+- **knowledge graph** with automatic entity extraction, directed relations, and N-hop recursive CTE traversal
+- **time-based decay** with 4 depth layers: core (forever), stable (~6 months), working (~1 week), ephemeral (~6 hours)
+- **trust scoring** with asymmetric feedback: helpful +0.05, unhelpful -0.10 for self-cleaning memory
+- **memory banks** using HRR bundled superpositions for O(1) category-level queries
+- **repository pattern** isolating all SQL into dedicated repository classes — zero raw SQL in business logic
+- **CLI** with commands: serve, init, search, stats, doctor, migrate (up/down/status), export, import
+- **interactive init** (`synapto init --interactive`) with MCP client auto-detection and uvx config
+- **multi-tenant isolation** via tenant scoping on all tables
+- **versioned SQL migrations** with up/down support and checksum validation
+- **embedding providers**: sentence-transformers (CPU default) and OpenAI
+- **CI pipeline** with lint (ruff), security (bandit), dependency audit (pip-audit), and tests across Python 3.11/3.12/3.13
+- **documentation** for Claude Code, Cursor, LangGraph, Agno integration
+- **docker compose** setup for quick start
+- **uvx support** as recommended installation method for automatic updates
+
+### Security
+
+- all SQL queries use parameterized placeholders (no string interpolation)
+- bandit static analysis integrated in CI
+- pip-audit dependency scanning in CI

--- a/README.md
+++ b/README.md
@@ -67,14 +67,16 @@ synapto init            # or: synapto init --interactive
 
 ### Connect to your agent
 
-**Claude Code** (`~/.claude/settings.json`):
+The recommended way is `uvx` — it auto-updates on every launch, no manual upgrades:
+
+**Claude Code** (`~/.claude/.mcp.json`):
 
 ```json
 {
   "mcpServers": {
     "synapto": {
-      "command": "synapto",
-      "args": ["serve"]
+      "command": "uvx",
+      "args": ["synapto", "serve"]
     }
   }
 }
@@ -86,12 +88,14 @@ synapto init            # or: synapto init --interactive
 {
   "mcpServers": {
     "synapto": {
-      "command": "synapto",
-      "args": ["serve"]
+      "command": "uvx",
+      "args": ["synapto", "serve"]
     }
   }
 }
 ```
+
+> **Why uvx?** It resolves the latest version from PyPI each time your agent starts. No `pip install --upgrade` needed — you always get the latest features and fixes automatically.
 
 Restart your agent. Synapto tools appear automatically.
 

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -12,27 +12,27 @@ synapto init
 
 2. Add to your Claude Code MCP config.
 
-**Global** (`~/.claude/settings.json`):
+**Recommended (auto-updates via uvx)** — add to `~/.claude/.mcp.json`:
 
 ```json
 {
   "mcpServers": {
     "synapto": {
-      "command": "synapto",
-      "args": ["serve"]
+      "command": "uvx",
+      "args": ["synapto", "serve"]
     }
   }
 }
 ```
 
-**Per-project** (`.claude/settings.json` in your repo root):
+**Per-project with tenant isolation** (`.claude/settings.json` in your repo root):
 
 ```json
 {
   "mcpServers": {
     "synapto": {
-      "command": "synapto",
-      "args": ["serve"],
+      "command": "uvx",
+      "args": ["synapto", "serve"],
       "env": {
         "SYNAPTO_DEFAULT_TENANT": "my-project"
       }
@@ -40,6 +40,8 @@ synapto init
   }
 }
 ```
+
+> **Why uvx?** It resolves the latest version from PyPI each time Claude Code starts the server. No manual `pip install --upgrade` needed.
 
 3. Restart Claude Code. Synapto tools will appear in your tool list.
 

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -12,12 +12,14 @@ synapto init
 
 2. Add to `.cursor/mcp.json` in your project root:
 
+**Recommended (auto-updates via uvx):**
+
 ```json
 {
   "mcpServers": {
     "synapto": {
-      "command": "synapto",
-      "args": ["serve"],
+      "command": "uvx",
+      "args": ["synapto", "serve"],
       "env": {
         "SYNAPTO_DEFAULT_TENANT": "my-project"
       }
@@ -25,6 +27,8 @@ synapto init
   }
 }
 ```
+
+> **Why uvx?** It resolves the latest version from PyPI each time Cursor starts the server. No manual `pip install --upgrade` needed.
 
 3. Restart Cursor. Synapto tools will be available to the AI agent.
 

--- a/src/synapto/cli.py
+++ b/src/synapto/cli.py
@@ -521,11 +521,11 @@ def import_cmd(file_path: str, tenant: str | None, fmt: str) -> None:
     _run(_import())
 
 
-def _detect_mcp_clients() -> list[dict]:
+def _detect_mcp_clients(home=None) -> list[dict]:
     """Detect installed MCP clients and their config paths."""
     from pathlib import Path
 
-    home = Path.home()
+    home = home or Path.home()
     clients = []
 
     # claude code

--- a/src/synapto/cli.py
+++ b/src/synapto/cli.py
@@ -86,6 +86,9 @@ def init(pg_dsn: str, interactive: bool) -> None:
         p = get_provider(provider)
         click.echo(f"embedding model ready: {p.name} (dim={p.dimension})")
 
+        # offer to write MCP client config
+        _offer_mcp_config(tenant)
+
         # summary
         click.echo("\n--- setup complete ---")
         click.echo(f"  postgresql: {pg_dsn}")
@@ -516,6 +519,68 @@ def import_cmd(file_path: str, tenant: str | None, fmt: str) -> None:
         await client.close()
 
     _run(_import())
+
+
+def _detect_mcp_clients() -> list[dict]:
+    """Detect installed MCP clients and their config paths."""
+    from pathlib import Path
+
+    home = Path.home()
+    clients = []
+
+    # claude code
+    for path in [home / ".claude" / ".mcp.json", home / ".claude" / "settings.json"]:
+        if path.parent.exists():
+            clients.append({"name": "Claude Code", "path": path, "key": "mcpServers"})
+            break
+
+    # cursor
+    cursor_path = home / ".cursor" / "mcp.json"
+    if cursor_path.parent.exists():
+        clients.append({"name": "Cursor", "path": cursor_path, "key": "mcpServers"})
+
+    return clients
+
+
+def _write_mcp_config(config_path, tenant: str = "default") -> None:
+    """Write synapto MCP config using uvx for auto-updates."""
+    from pathlib import Path
+
+    path = Path(config_path)
+    existing = {}
+    if path.exists():
+        with open(path) as f:
+            existing = json.loads(f.read())
+
+    servers = existing.get("mcpServers", {})
+    server_config: dict = {
+        "command": "uvx",
+        "args": ["synapto", "serve"],
+    }
+    if tenant != "default":
+        server_config["env"] = {"SYNAPTO_DEFAULT_TENANT": tenant}
+
+    servers["synapto"] = server_config
+    existing["mcpServers"] = servers
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        f.write(json.dumps(existing, indent=2))
+
+
+def _offer_mcp_config(tenant: str = "default") -> None:
+    """Detect MCP clients and offer to write uvx-based config."""
+    clients = _detect_mcp_clients()
+    if not clients:
+        return
+
+    click.echo("\n--- mcp client configuration ---")
+    for client in clients:
+        if click.confirm(f"configure {client['name']} with auto-update (uvx)?", default=True):
+            _write_mcp_config(client["path"], tenant)
+            click.echo(f"  written: {client['path']}")
+        else:
+            click.echo(f"  skipped: {client['name']}")
 
 
 def _parse_markdown_memories(text: str, tenant: str) -> list[dict]:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,92 @@
+"""Unit tests for CLI MCP client detection and config writing."""
+
+from __future__ import annotations
+
+import json
+
+from synapto.cli import _detect_mcp_clients, _write_mcp_config
+
+
+class TestDetectMcpClients:
+    def test_detects_claude_code(self, tmp_path):
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+
+        clients = _detect_mcp_clients(home=tmp_path)
+        names = [c["name"] for c in clients]
+        assert "Claude Code" in names
+
+    def test_detects_cursor(self, tmp_path):
+        cursor_dir = tmp_path / ".cursor"
+        cursor_dir.mkdir()
+
+        clients = _detect_mcp_clients(home=tmp_path)
+        names = [c["name"] for c in clients]
+        assert "Cursor" in names
+
+    def test_detects_both(self, tmp_path):
+        (tmp_path / ".claude").mkdir()
+        (tmp_path / ".cursor").mkdir()
+
+        clients = _detect_mcp_clients(home=tmp_path)
+        assert len(clients) == 2
+
+    def test_detects_none(self, tmp_path):
+        clients = _detect_mcp_clients(home=tmp_path)
+        assert len(clients) == 0
+
+
+class TestWriteMcpConfig:
+    def test_creates_new_config(self, tmp_path):
+        config_path = tmp_path / "mcp.json"
+
+        _write_mcp_config(config_path, tenant="default")
+
+        data = json.loads(config_path.read_text())
+        assert data["mcpServers"]["synapto"]["command"] == "uvx"
+        assert data["mcpServers"]["synapto"]["args"] == ["synapto", "serve"]
+        assert "env" not in data["mcpServers"]["synapto"]
+
+    def test_creates_config_with_custom_tenant(self, tmp_path):
+        config_path = tmp_path / "mcp.json"
+
+        _write_mcp_config(config_path, tenant="my-project")
+
+        data = json.loads(config_path.read_text())
+        assert data["mcpServers"]["synapto"]["env"]["SYNAPTO_DEFAULT_TENANT"] == "my-project"
+
+    def test_preserves_existing_servers(self, tmp_path):
+        config_path = tmp_path / "mcp.json"
+        config_path.write_text(json.dumps({
+            "mcpServers": {
+                "other-server": {"command": "other", "args": ["serve"]}
+            }
+        }))
+
+        _write_mcp_config(config_path, tenant="default")
+
+        data = json.loads(config_path.read_text())
+        assert "other-server" in data["mcpServers"]
+        assert "synapto" in data["mcpServers"]
+
+    def test_overwrites_existing_synapto_config(self, tmp_path):
+        config_path = tmp_path / "mcp.json"
+        config_path.write_text(json.dumps({
+            "mcpServers": {
+                "synapto": {"command": "/old/path/synapto", "args": ["serve"]}
+            }
+        }))
+
+        _write_mcp_config(config_path, tenant="default")
+
+        data = json.loads(config_path.read_text())
+        assert data["mcpServers"]["synapto"]["command"] == "uvx"
+
+    def test_creates_parent_directories(self, tmp_path):
+        config_path = tmp_path / "nested" / "dir" / "mcp.json"
+
+        _write_mcp_config(config_path, tenant="default")
+
+        assert config_path.exists()
+        data = json.loads(config_path.read_text())
+        assert data["mcpServers"]["synapto"]["command"] == "uvx"


### PR DESCRIPTION
## Summary

- implement issue #3 (items 1 and 3): uvx as default mcp config and auto-detection in `synapto init`
- add CHANGELOG.md for v0.1.0
- update release workflow to use uv and include install instructions in release notes

## Changes

- **README.md** — recommend uvx as default mcp config with explanation
- **docs/claude-code.md** — updated mcp config examples with uvx
- **docs/cursor.md** — updated mcp config examples with uvx
- **src/synapto/cli.py** — `synapto init --interactive` now detects claude code and cursor, offers to write uvx-based mcp config automatically
- **CHANGELOG.md** — documents all features shipping in v0.1.0
- **.github/workflows/release.yml** — uses uv, includes install/upgrade instructions in github release notes

## Release Process (after merge)

1. go to actions → release → run workflow
2. select bump type (patch/minor/major)
3. workflow bumps version, builds, publishes to pypi, creates github release

## Test plan

- [ ] ci passes (lint, security, test 3.11/3.12/3.13)
- [ ] `synapto init --interactive` detects claude code and offers uvx config
- [ ] CHANGELOG.md accurately reflects v0.1.0 features

closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)