### PR TITLE
feat(server): inject mcp instructions to guide llm memory behavior (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Synapto will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **server instructions** injected into MCP clients via `FastMCP(instructions=...)` so the LLM knows when to call `recall` and `remember` without requiring manual CLAUDE.md configuration (#11)
+
 ## [0.1.0] - 2026-04-13
 
 ### Added

--- a/src/synapto/prompts/__init__.py
+++ b/src/synapto/prompts/__init__.py
@@ -1,0 +1,33 @@
+"""Prompt loader — reads package-bundled prompt files via importlib.resources.
+
+Prompts live as plain `.md` files next to this module so they can be reviewed,
+versioned, and edited without touching Python code. Using `importlib.resources`
+keeps loading compatible with every install scheme (wheel, editable, uvx, zipapp).
+"""
+
+from __future__ import annotations
+
+from functools import cache
+from importlib.resources import files
+
+
+@cache
+def load_prompt(name: str) -> str:
+    """Load a prompt by name from `synapto/prompts/{name}.md`.
+
+    Args:
+        name: prompt file stem (without extension), e.g. `"server_instructions"`.
+
+    Returns:
+        The prompt body as a string.
+
+    Raises:
+        FileNotFoundError: if no matching `.md` file exists in the package.
+    """
+    resource = files(__package__).joinpath(f"{name}.md")
+    if not resource.is_file():
+        raise FileNotFoundError(f"prompt not found: {name}.md")
+    return resource.read_text(encoding="utf-8")
+
+
+__all__ = ["load_prompt"]

--- a/src/synapto/prompts/server_instructions.md
+++ b/src/synapto/prompts/server_instructions.md
@@ -1,0 +1,30 @@
+Synapto is the user's persistent memory system. Prefer it over flat files
+(MEMORY.md, CLAUDE.md notes, etc.) for storing new memories.
+
+When to call `recall`:
+- At the start of any non-trivial task, to load relevant context.
+- When the user references past decisions, history, or preferences
+  (e.g. "remember", "lembra", "do you know", "what do we know about").
+- Before creating PRs, commits, or deploys — to confirm workflow rules.
+
+When to call `remember`:
+- The user sets a rule ("always X", "never Y", "from now on") → feedback/core.
+- The user corrects you ("don't do X", "that's wrong") → feedback/core.
+- The user confirms a non-obvious approach ("yes exactly") → feedback/stable.
+- The user shares project context, architecture, or decisions → project/stable.
+- The user mentions temporal context ("this sprint", "deadline") → project/working.
+- The user shares identity, role, or long-term preferences → user/stable.
+- The user references external systems ("tracked in Linear") → reference/stable.
+
+When to call `relate` and `graph_query`:
+- After storing memories that reference named entities, create relations so the
+  graph can be traversed by `graph_query` (e.g. service A depends_on service B).
+
+Depth layers control decay:
+- core: forever (rules, identity)
+- stable: months (architecture, reference)
+- working: weeks (active projects)
+- ephemeral: hours (short-lived state)
+
+If `recall` returns a memory that conflicts with what you observe now, trust the
+current state and update or `forget` the stale memory.

--- a/src/synapto/server.py
+++ b/src/synapto/server.py
@@ -21,6 +21,7 @@ from synapto.graph.relations import create_relation_by_name
 from synapto.hrr.banks import rebuild_bank
 from synapto.hrr.core import DEFAULT_DIM, encode_fact, phases_to_bytes
 from synapto.hrr.retrieval import contradict as hrr_contradict
+from synapto.prompts import load_prompt
 from synapto.repositories.entities import EntityRepository
 from synapto.repositories.memories import MemoryRepository
 from synapto.repositories.relations import RelationRepository
@@ -87,7 +88,9 @@ async def _lifespan(server):
         logger.info("synapto MCP server shut down")
 
 
-mcp = FastMCP("synapto", lifespan=_lifespan)
+SERVER_INSTRUCTIONS = load_prompt("server_instructions")
+
+mcp = FastMCP("synapto", instructions=SERVER_INSTRUCTIONS, lifespan=_lifespan)
 
 
 @mcp.tool

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -1,0 +1,23 @@
+"""Unit tests for the prompt loader (issue #11)."""
+
+from __future__ import annotations
+
+import pytest
+
+from synapto.prompts import load_prompt
+
+
+def test_load_prompt_returns_non_empty_string():
+    content = load_prompt("server_instructions")
+    assert isinstance(content, str)
+    assert content.strip(), "loaded prompt must not be empty"
+
+
+def test_load_prompt_is_cached():
+    """Consecutive calls must return the exact same cached string object."""
+    assert load_prompt("server_instructions") is load_prompt("server_instructions")
+
+
+def test_load_prompt_raises_for_missing_file():
+    with pytest.raises(FileNotFoundError, match="nonexistent_prompt.md"):
+        load_prompt("nonexistent_prompt")

--- a/tests/unit/test_server_instructions.py
+++ b/tests/unit/test_server_instructions.py
@@ -1,0 +1,31 @@
+"""Unit tests for Synapto MCP server instructions (issue #11)."""
+
+from __future__ import annotations
+
+from synapto.server import SERVER_INSTRUCTIONS, mcp
+
+
+def test_server_instructions_constant_is_non_empty():
+    assert isinstance(SERVER_INSTRUCTIONS, str)
+    assert SERVER_INSTRUCTIONS.strip(), "SERVER_INSTRUCTIONS must not be empty"
+
+
+def test_server_instructions_mention_core_tools():
+    """Instructions must reference the main tools so the LLM knows when to use them."""
+    for tool in ("recall", "remember"):
+        assert tool in SERVER_INSTRUCTIONS, f"instructions should mention {tool!r}"
+
+
+def test_server_instructions_cover_depth_layers():
+    for layer in ("core", "stable", "working", "ephemeral"):
+        assert layer in SERVER_INSTRUCTIONS, f"instructions should mention {layer!r}"
+
+
+def test_server_instructions_cover_memory_types():
+    for mtype in ("feedback", "project", "user", "reference"):
+        assert mtype in SERVER_INSTRUCTIONS, f"instructions should mention {mtype!r}"
+
+
+def test_fastmcp_instance_has_instructions_attached():
+    """The FastMCP instance must expose the instructions so MCP clients can inject them."""
+    assert mcp.instructions == SERVER_INSTRUCTIONS


### PR DESCRIPTION
## Summary

- Introduces a FastMCP `instructions` payload so any MCP client (Claude Code, Cursor, ...) receives guidance on when to call `recall` / `remember` automatically during the `initialize` handshake — no manual CLAUDE.md setup required.
- Adds a reusable `synapto.prompts` subpackage backed by `importlib.resources`, so prompt content lives in markdown files that ship inside the wheel and can be edited without touching Python code. This scaffolding is reused by upcoming issues in the `v0.2.0` "Claude Experience" milestone.

## Changes

- `src/synapto/prompts/__init__.py` — stdlib-only `load_prompt(name)` helper, `@functools.cache` for zero-overhead reuse, `FileNotFoundError` on missing prompts.
- `src/synapto/prompts/server_instructions.md` — the actual instruction text. Covers when to call each tool, memory type categorization, depth layers, and conflict resolution.
- `src/synapto/server.py` — wires `FastMCP(instructions=load_prompt("server_instructions"))`.
- `tests/unit/test_prompts.py` (3 tests) — loader happy path, caching identity, missing-file error.
- `tests/unit/test_server_instructions.py` (5 tests) — instructions non-empty, mention core tools, cover all depth layers, cover all memory types, attached to the FastMCP instance.
- `CHANGELOG.md` — `[Unreleased]` entry.

## Design notes

- Markdown over YAML/JSON because the content is plain text for an LLM, not configuration — no parser needed, diffs are readable, no escape hell.
- `importlib.resources.files(__package__)` is the canonical stdlib loader for Python >=3.9 and is robust across wheel / editable / uvx / zipapp / frozen installs.
- Hatchling already packages `src/synapto/` as-is, so no `pyproject.toml` change was necessary. Verified by `uv build --wheel` — the `.md` is present inside the generated wheel.

## Test plan

- [x] `uv run pytest tests/unit/test_prompts.py tests/unit/test_server_instructions.py` — 8/8 passing
- [x] `uv run ruff check` and `ruff format --check` — clean
- [x] `uv build --wheel` — `synapto/prompts/server_instructions.md` present in the wheel
- [x] Manual sanity check — `from synapto.server import mcp; mcp.instructions` returns the expected text
- [x] Behavioral check in a live Claude Code session — the agent calls `recall` proactively at the start of new tasks

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)