### PR TITLE
chore(deps): constrain authlib >=1.6.11 to fix GHSA-jj8c-mmj3-mmgv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,10 @@ classifiers = [
 ]
 dependencies = [
     "fastmcp>=2.0.0",
+    # pinned to fix GHSA-jj8c-mmj3-mmgv (CSRF in OAuth client cache);
+    # fastmcp still ships the vulnerable range transitively — drop this once
+    # fastmcp upstream bumps authlib itself
+    "authlib>=1.6.11",
     "psycopg[binary,pool]>=3.1",
     "pgvector>=0.3.0",
     "redis>=5.0",

--- a/uv.lock
+++ b/uv.lock
@@ -65,14 +65,15 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.9"
+version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
+    { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134, upload-time = "2026-03-02T07:44:01.998Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/82/4d0603f30c1b4629b1f091bb266b0d7986434891d6940a8c87f8098db24e/authlib-1.7.0.tar.gz", hash = "sha256:b3e326c9aa9cc3ea95fe7d89fd880722d3608da4d00e8a27e061e64b48d801d5", size = 175890, upload-time = "2026-04-18T11:00:28.559Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/23/b65f568ed0c22f1efacb744d2db1a33c8068f384b8c9b482b52ebdbc3ef6/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3", size = 244197, upload-time = "2026-03-02T07:44:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/48/c954218b2a250e23f178f10167c4173fecb5a75d2c206f0a67ba58006c26/authlib-1.7.0-py2.py3-none-any.whl", hash = "sha256:e36817afb02f6f0b6bf55f150782499ddd6ddf44b402bb055d3263cc65ac9ae0", size = 258779, upload-time = "2026-04-18T11:00:26.64Z" },
 ]
 
 [[package]]
@@ -1039,6 +1040,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/c6/de8fdbdfa75c8ca04fead38a82d573df8a82906e984c349d58665f459558/joserfc-1.6.4.tar.gz", hash = "sha256:34ce5f499bfcc5e9ad4cc75077f9278ab3227b71da9aaf28f9ab705f8a560d3c", size = 231866, upload-time = "2026-04-13T13:15:40.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/f7/210b27752e972edb36d239315b08d3eb6b14824cc4a590da2337d195260b/joserfc-1.6.4-py3-none-any.whl", hash = "sha256:3e4a22b509b41908989237a045e25c8308d5fd47ab96bdae2dd8057c6451003a", size = 70464, upload-time = "2026-04-13T13:15:39.259Z" },
 ]
 
 [[package]]
@@ -2727,6 +2740,7 @@ name = "synapto"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "authlib" },
     { name = "click" },
     { name = "fastmcp" },
     { name = "numpy" },
@@ -2754,6 +2768,7 @@ openai = [
 
 [package.metadata]
 requires-dist = [
+    { name = "authlib", specifier = ">=1.6.11" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7" },
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "click", specifier = ">=8.0" },


### PR DESCRIPTION
## Summary

- `fastmcp 3.2.x` pulls in `authlib 1.6.9` transitively, which ships a moderate CSRF vulnerability in its OAuth client cache path ([GHSA-jj8c-mmj3-mmgv](https://github.com/advisories/GHSA-jj8c-mmj3-mmgv), CVSS 5.4, fixed upstream in `authlib 1.6.11`).
- Synapto does **not** use the OAuth client flow, so the vulnerability is not exploitable in practice, but `pip-audit` rightfully fails the CI `security` job and blocks every subsequent PR (including #19).
- Pin `authlib` as a direct top-level dependency so the resolver picks the patched `1.7.0` release until `fastmcp` ships a version that constrains `authlib` itself.

## Changes

- `pyproject.toml` — add `authlib>=1.6.11` to `dependencies` with an inline comment explaining the pin and when it can be removed.
- `uv.lock` — `authlib 1.6.9 → 1.7.0` (adds transitive `joserfc 1.6.4`).

## Verification

- [x] `uv lock` resolves cleanly
- [x] `uv run pip-audit` — **"No known vulnerabilities found"**
- [x] `uv run pytest tests/unit -q` — 98 passed
- [x] `uv run ruff check src/ tests/` — clean

## Follow-up

Once `fastmcp` ships a release that pins `authlib>=1.6.11` transitively, drop the direct pin from `pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)