### PR TITLE
docs(claude-code): document memory type alignment with claude code (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - **server instructions** injected into MCP clients via `FastMCP(instructions=...)` so the LLM knows when to call `recall` and `remember` without requiring manual CLAUDE.md configuration (#11)
 
+### Documentation
+
+- **memory type alignment with Claude Code** — `docs/claude-code.md` now documents that Synapto's `user`, `feedback`, `project`, and `reference` types are a direct 1:1 match with Claude Code's native auto-memory types, enabling zero-transformation import of existing memories (#12)
+
 ## [0.1.0] - 2026-04-13
 
 ### Added

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -54,6 +54,51 @@ Claude Code will automatically use Synapto tools. You can also ask directly:
 - "What depends on the agent.trigger topic?"
 - "Show me memory stats"
 
+## Memory type alignment
+
+Synapto's `memory_type` categories are **100% compatible** with Claude Code's native
+auto-memory types. No translation layer, mapping table, or converter is required
+when moving memories between the two systems.
+
+| Type | Claude Code meaning | Synapto meaning |
+|------|--------------------|-----------------|
+| `user` | Who the user is — role, goals, knowledge, preferences | Same |
+| `feedback` | How to work — rules, corrections, confirmed approaches | Same |
+| `project` | What the project is — goals, incidents, temporal context | Same |
+| `reference` | Where to find things — external systems, links, locations | Same |
+| `general` | _(not present — Claude Code has no catch-all)_ | Catch-all for memories that don't fit the four canonical types |
+
+Claude Code defines the same four types in
+[`src/memdir/memoryTypes.ts`](https://github.com/anthropics/claude-code) with
+identical semantics. Since Synapto mirrors them exactly, any memory Claude Code
+produces via its auto-memory flow can be stored in Synapto without modification.
+
+### Frontmatter format
+
+Claude Code's auto-memory files use YAML frontmatter with `name`, `description`,
+and `type` fields:
+
+```markdown
+---
+name: git workflow
+description: branching and commit conventions for this project
+type: feedback
+---
+
+Always branch off `main`, never commit directly. Commit messages must follow …
+```
+
+When importing such files into Synapto, the mapping is direct:
+
+| Frontmatter field | Synapto field |
+|-------------------|---------------|
+| `type` | `memory_type` |
+| `description` | `summary` |
+| body (after `---`) | `content` |
+| _(implicit)_ | `depth_layer` defaults to `stable` for imported files |
+
+This enables the upcoming auto-migration flow ([issue #8](https://github.com/ramonlimaramos/synapto/issues/8)) to ingest existing Claude Code memories with zero transformation.
+
 ## Migrating from MEMORY.md
 
 ```bash


### PR DESCRIPTION
## Summary

- Document that Synapto's `memory_type` categories (`user`, `feedback`, `project`, `reference`) are a **1:1 match** with Claude Code's native auto-memory types, so memories can move between the two systems without any conversion layer.
- Record the frontmatter format Claude Code produces and the direct field-by-field mapping into Synapto, which is the foundation for the upcoming auto-migration flow ([#8](https://github.com/ramonlimaramos/synapto/issues/8)).

## Changes

- `docs/claude-code.md` — new "Memory type alignment" section with a type-comparison table, a frontmatter example, and a frontmatter → Synapto field mapping table. Notes the extra `general` catch-all that Synapto exposes for memories that do not fit the four canonical buckets.
- `CHANGELOG.md` — `[Unreleased] → Documentation` entry.

## Test plan

- [x] `docs/claude-code.md` renders cleanly on GitHub (tables + code fences verified)
- [x] No code paths touched; no tests required for a doc-only change
- [x] Existing CI (`lint`, `security`, `test`) still relevant only to confirm no accidental code change — expected green

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)