### PR TITLE
feat(server): mark remember and recall as alwaysLoad to skip toolsearch (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Added
 
 - **server instructions** injected into MCP clients via `FastMCP(instructions=...)` so the LLM knows when to call `recall` and `remember` without requiring manual CLAUDE.md configuration (#11)
+- **`alwaysLoad` tool metadata** on `remember` and `recall` so Claude Code loads their schemas eagerly and skips the deferred `ToolSearch` round-trip — reduces first-call latency while keeping the other eight tools deferred (#15)
 
 ### Documentation
 

--- a/src/synapto/server.py
+++ b/src/synapto/server.py
@@ -90,10 +90,15 @@ async def _lifespan(server):
 
 SERVER_INSTRUCTIONS = load_prompt("server_instructions")
 
+# Marks a tool so Claude Code (and any MCP client that honors `_meta.alwaysLoad`)
+# skips the deferred-tool `ToolSearch` handshake and loads the schema eagerly.
+# Reserved for the two tools the LLM is expected to call in most conversations.
+ALWAYS_LOAD_META = {"alwaysLoad": True}
+
 mcp = FastMCP("synapto", instructions=SERVER_INSTRUCTIONS, lifespan=_lifespan)
 
 
-@mcp.tool
+@mcp.tool(meta=ALWAYS_LOAD_META)
 async def remember(
     content: str,
     memory_type: str = "general",
@@ -153,7 +158,7 @@ async def remember(
     return f"stored memory {memory_id} ({depth_layer}, {entity_count} entities linked)"
 
 
-@mcp.tool
+@mcp.tool(meta=ALWAYS_LOAD_META)
 async def recall(
     query: str,
     tenant: str | None = None,

--- a/tests/unit/test_tool_metadata.py
+++ b/tests/unit/test_tool_metadata.py
@@ -1,0 +1,40 @@
+"""Unit tests for Synapto MCP tool metadata — `alwaysLoad` flag (issue #15)."""
+
+from __future__ import annotations
+
+import pytest
+
+from synapto.server import ALWAYS_LOAD_META, mcp
+
+ALWAYS_LOAD_TOOLS = ("remember", "recall")
+DEFERRED_TOOLS = (
+    "relate",
+    "forget",
+    "trust_feedback",
+    "find_contradictions",
+    "graph_query",
+    "list_entities_tool",
+    "memory_stats",
+    "maintain",
+)
+
+
+def test_always_load_meta_constant_shape():
+    assert ALWAYS_LOAD_META == {"alwaysLoad": True}
+
+
+@pytest.mark.parametrize("name", ALWAYS_LOAD_TOOLS)
+async def test_critical_tools_carry_always_load_meta(name: str):
+    """`remember` and `recall` must ship `alwaysLoad: true` so MCP clients skip ToolSearch."""
+    tool = await mcp.get_tool(name)
+    assert tool.meta == ALWAYS_LOAD_META, (
+        f"{name!r} must expose alwaysLoad metadata so Claude Code loads it eagerly"
+    )
+
+
+@pytest.mark.parametrize("name", DEFERRED_TOOLS)
+async def test_non_critical_tools_stay_deferred(name: str):
+    """Only `remember` and `recall` should be marked alwaysLoad — the rest must stay deferred
+    so they do not bloat the LLM's tool list on every session."""
+    tool = await mcp.get_tool(name)
+    assert tool.meta is None, f"{name!r} should not carry alwaysLoad metadata"


### PR DESCRIPTION
## Summary

- MCP tools are deferred by default in Claude Code — the first call in a session requires a `ToolSearch` round-trip to load the schema. For the two tools the LLM is expected to use in almost every conversation (`remember` and `recall`), this extra hop adds latency with no benefit.
- FastMCP exposes arbitrary tool metadata through the `meta` decorator parameter, which is serialized as `_meta` in the MCP protocol. Setting `_meta.alwaysLoad = true` is the signal Claude Code honors to load the tool eagerly and skip `ToolSearch` entirely.
- Keeps the other eight tools deferred on purpose so they do not bloat the LLM's tool list on every session.

## Changes

- `src/synapto/server.py`
  - add `ALWAYS_LOAD_META` module-level constant so both decorators share a single source of truth
  - convert `@mcp.tool` to `@mcp.tool(meta=ALWAYS_LOAD_META)` on `remember` and `recall` only
- `tests/unit/test_tool_metadata.py` — new file, 11 tests:
  - `test_always_load_meta_constant_shape` — sanity check on the constant payload
  - 2 parametrized positive tests: `remember` / `recall` expose `{'alwaysLoad': True}`
  - 8 parametrized negative tests: `relate`, `forget`, `trust_feedback`, `find_contradictions`, `graph_query`, `list_entities_tool`, `memory_stats`, `maintain` must stay deferred (`meta is None`)
- `CHANGELOG.md` — `[Unreleased] → Added` entry.

## Test plan

- [x] `uv run pytest tests/unit/test_tool_metadata.py tests/unit/test_server_instructions.py tests/unit/test_prompts.py -v` — 19/19 passing
- [x] `uv run ruff check src/synapto/server.py tests/unit/test_tool_metadata.py` — clean
- [x] Runtime check — `mcp.get_tool('remember').meta == {'alwaysLoad': True}`, `mcp.get_tool('recall').meta == {'alwaysLoad': True}`, all other tools `meta is None`
- [x] Live Claude Code behavioral check — in a fresh session, asking the agent to call `recall` routes directly to `mcp__synapto__recall` with **no preceding `ToolSearch` round-trip**, confirming the client honors `_meta.alwaysLoad`

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)