### PR TITLE
chore(release): bump version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-22
+
 ### Added
 
 - **server instructions** injected into MCP clients via `FastMCP(instructions=...)` so the LLM knows when to call `recall` and `remember` without requiring manual CLAUDE.md configuration (#11)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "synapto"
-version = "0.1.0"
+version = "0.2.0"
 description = "Persistent memory graph for AI coding agents — semantic search, knowledge graph, and time-based decay over MCP"
 readme = "README.md"
 license = "MIT"

--- a/src/synapto/__init__.py
+++ b/src/synapto/__init__.py
@@ -1,3 +1,3 @@
 """Synapto — persistent memory graph for AI coding agents."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2737,7 +2737,7 @@ wheels = [
 
 [[package]]
 name = "synapto"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
## Summary

Promotes the `[Unreleased]` section of the CHANGELOG to `[0.2.0] - 2026-04-22` and pins `pyproject.toml` and `synapto.__version__` to `0.2.0`.

Packages the **Claude Experience: DX** phase of the roadmap for publication:

- #11 — server instructions via FastMCP `instructions` payload
- #12 — memory type alignment with Claude Code (docs)
- #15 — `alwaysLoad` metadata on `remember` / `recall`
- #16 — `<system-reminder>` wrapping on `recall` output

## Why this PR exists

The release workflow tries to commit the version bump and push it directly to `main`, which is rejected by branch protection (`GH006: Protected branch update failed`). This PR performs the bump through the normal PR path so protection is respected.

After merge, re-trigger `release.yml` with `bump_type: current` — that code path skips the commit-and-push step (the guard `if: inputs.bump_type != 'current'`) and goes directly to `tag → PyPI publish → GitHub Release`, which is exactly what is left to do once the version is already on `main`.

A follow-up issue should rewrite `release.yml` to use a PR-based flow natively so future releases do not require this manual workaround.

## Changes

- `pyproject.toml` — `version = "0.1.0"` → `"0.2.0"`
- `src/synapto/__init__.py` — `__version__ = "0.1.0"` → `"0.2.0"`
- `CHANGELOG.md` — insert `## [0.2.0] - 2026-04-22` above the existing `[Unreleased]` content (all entries in `[Unreleased]` were already written for this release)

## Test plan

- [x] `uv run pytest tests/unit -q` — 122/122 passing
- [x] `uv run ruff check src/ tests/` — clean
- [x] `python -c "import synapto; print(synapto.__version__)"` → `0.2.0`