### PR TITLE
docs(install): recommend uvx --refresh so users actually receive updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Documentation
+
+- **install snippets use `uvx --refresh`** so users actually receive new releases on Claude Code / Cursor restart — the previous snippets relied on `uvx` reusing its package cache, which meant a published Synapto release could go unnoticed until the cache expired. README, `docs/claude-code.md`, and `docs/cursor.md` now recommend the `--refresh` flag, document the startup tradeoff, and describe the manual `uv cache clean synapto` escape hatch. Also explains why a full Claude Code quit is required to pick up a new version mid-session.
+
 ## [0.2.0] - 2026-04-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ synapto init            # or: synapto init --interactive
 
 ### Connect to your agent
 
-The recommended way is `uvx` — it auto-updates on every launch, no manual upgrades:
+The recommended way is `uvx` with `--refresh` — every restart pulls the latest version from PyPI, no manual upgrades:
 
 **Claude Code** (`~/.claude/.mcp.json`):
 
@@ -76,7 +76,7 @@ The recommended way is `uvx` — it auto-updates on every launch, no manual upgr
   "mcpServers": {
     "synapto": {
       "command": "uvx",
-      "args": ["synapto", "serve"]
+      "args": ["--refresh", "synapto", "serve"]
     }
   }
 }
@@ -89,15 +89,15 @@ The recommended way is `uvx` — it auto-updates on every launch, no manual upgr
   "mcpServers": {
     "synapto": {
       "command": "uvx",
-      "args": ["synapto", "serve"]
+      "args": ["--refresh", "synapto", "serve"]
     }
   }
 }
 ```
 
-> **Why uvx?** It resolves the latest version from PyPI each time your agent starts. No `pip install --upgrade` needed — you always get the latest features and fixes automatically.
+> **Why `--refresh`?** Without it, `uvx` reuses the cached environment across restarts, so a new Synapto release on PyPI will not be picked up until the cache expires or you run `uv cache clean synapto` manually. `--refresh` tells `uv` to re-resolve the package on every launch, adding 1–3 seconds to startup in exchange for "always on the latest version" — the right default for an alpha project that ships often. Drop the flag (or pin a version like `"synapto==0.2.0"`) if you want to freeze the version.
 
-Restart your agent. Synapto tools appear automatically.
+Restart your agent. Synapto tools appear automatically, and any future release will be live on the next restart.
 
 ## MCP Tools
 

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -12,14 +12,14 @@ synapto init
 
 2. Add to your Claude Code MCP config.
 
-**Recommended (auto-updates via uvx)** — add to `~/.claude/.mcp.json`:
+**Recommended (auto-updates on every restart)** — add to `~/.claude/.mcp.json`:
 
 ```json
 {
   "mcpServers": {
     "synapto": {
       "command": "uvx",
-      "args": ["synapto", "serve"]
+      "args": ["--refresh", "synapto", "serve"]
     }
   }
 }
@@ -32,7 +32,7 @@ synapto init
   "mcpServers": {
     "synapto": {
       "command": "uvx",
-      "args": ["synapto", "serve"],
+      "args": ["--refresh", "synapto", "serve"],
       "env": {
         "SYNAPTO_DEFAULT_TENANT": "my-project"
       }
@@ -41,7 +41,20 @@ synapto init
 }
 ```
 
-> **Why uvx?** It resolves the latest version from PyPI each time Claude Code starts the server. No manual `pip install --upgrade` needed.
+> **Why `--refresh`?** Without it, `uvx` reuses the cached environment across restarts, so a new Synapto release on PyPI will not be picked up until the cache expires or you run `uv cache clean synapto` manually. `--refresh` tells `uv` to re-resolve the package on every launch, adding 1–3 seconds to Claude Code's MCP startup in exchange for "always on the latest version" — the right default while Synapto is shipping fast. Drop the flag (or pin a version like `"synapto==0.2.0"`) once you want to freeze a known-good build.
+
+### Upgrading mid-session
+
+If a new Synapto release lands while Claude Code is already running, the existing MCP subprocess keeps using the version it started with. To pick up the new release, **fully quit Claude Code (`Cmd+Q`) and relaunch** — the MCP server is a child process of Claude Code, so a window-close is not enough. With `--refresh` in place, the relaunch will pull the new version automatically.
+
+### Forcing an upgrade without `--refresh`
+
+If you pinned the config without `--refresh` and want a one-time upgrade:
+
+```bash
+uv cache clean synapto   # invalidate the cached env
+# then relaunch Claude Code
+```
 
 3. Restart Claude Code. Synapto tools will appear in your tool list.
 

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -12,14 +12,14 @@ synapto init
 
 2. Add to `.cursor/mcp.json` in your project root:
 
-**Recommended (auto-updates via uvx):**
+**Recommended (auto-updates on every restart):**
 
 ```json
 {
   "mcpServers": {
     "synapto": {
       "command": "uvx",
-      "args": ["synapto", "serve"],
+      "args": ["--refresh", "synapto", "serve"],
       "env": {
         "SYNAPTO_DEFAULT_TENANT": "my-project"
       }
@@ -28,7 +28,7 @@ synapto init
 }
 ```
 
-> **Why uvx?** It resolves the latest version from PyPI each time Cursor starts the server. No manual `pip install --upgrade` needed.
+> **Why `--refresh`?** Without it, `uvx` reuses the cached environment across restarts, so a new Synapto release on PyPI will not be picked up until the cache expires or you run `uv cache clean synapto` manually. `--refresh` tells `uv` to re-resolve the package on every launch, adding 1–3 seconds to startup in exchange for "always on the latest version". Drop the flag (or pin a version like `"synapto==0.2.0"`) once you want to freeze a known-good build.
 
 3. Restart Cursor. Synapto tools will be available to the AI agent.
 


### PR DESCRIPTION
## Summary

- The previous install snippets claimed `uvx synapto serve` auto-updates on every launch. **It doesn't** — `uvx` reuses its cached environment, so a new Synapto release on PyPI stays invisible to users until the cache expires naturally or they run `uv cache clean synapto` manually.
- Switch the recommended snippet to `uvx --refresh synapto serve`, which forces `uv` to re-resolve the package on every launch. Roughly 1–3 seconds of extra startup time in exchange for genuine "always on the latest version" behavior — the right default while Synapto is in alpha and shipping fast.
- Also clarify the upgrade semantics for users who pin the version or want manual control.

## Why this matters

Discovered while validating the v0.2.0 release. The author's own machine silently kept running `0.1.0` after the release went live on PyPI, because `uvx` reused its cache. The docs told users to expect automatic updates that were not actually happening — time to make the docs match the behavior we want.

## Changes

- `README.md`
  - Claude Code and Cursor snippets now include `--refresh`
  - Rewrite the "Why uvx?" explainer to be honest about the caching model and describe the tradeoff
- `docs/claude-code.md`
  - Same snippet update
  - New "Upgrading mid-session" section explaining that a full `Cmd+Q` is required because the MCP server is a subprocess of Claude Code — window-close is not enough
  - New "Forcing an upgrade without `--refresh`" section for setups that pin a known-good version
- `docs/cursor.md`
  - Same snippet update and explainer rewrite
- `CHANGELOG.md`
  - `[Unreleased] → Documentation` entry

## Test plan

- [x] Snippets render correctly on GitHub (preview in PR view)
- [x] No code paths touched; no unit tests required
- [x] Manual verification: on the author's machine, `uvx synapto serve` was resolving `0.1.0` from cache despite `0.2.0` being published — the new snippet pulls `0.2.0` immediately