### PR TITLE
feat: auto-detect and parse Claude Code memories for migration

### DIFF
--- a/src/synapto/cli.py
+++ b/src/synapto/cli.py
@@ -596,8 +596,14 @@ def _offer_memory_migration() -> None:
     from synapto.migration.detect import detect_all
 
     click.echo("\n--- memory migration ---")
-    click.echo("scanning for existing memories...")
+    if not click.confirm(
+        "scan ~/.claude/projects for existing AI agent memories?",
+        default=True,
+    ):
+        click.echo("  skipped")
+        return
 
+    click.echo("scanning for existing memories...")
     result = detect_all()
     if not result.sources:
         click.echo("no existing memories found")
@@ -671,7 +677,7 @@ def migrate_memories(dry_run: bool, home: str | None) -> None:
         return
 
     async def _do_import():
-        from datetime import datetime, timezone
+        from datetime import UTC, datetime
 
         from psycopg.types.json import Jsonb
 
@@ -706,7 +712,7 @@ def migrate_memories(dry_run: bool, home: str | None) -> None:
             await client.close()
             return 0
 
-        migrated_at = datetime.now(timezone.utc).isoformat()
+        migrated_at = datetime.now(UTC).isoformat()
         count = 0
 
         # Embed in batches — one provider round-trip per N texts instead of per memory.

--- a/src/synapto/cli.py
+++ b/src/synapto/cli.py
@@ -10,6 +10,11 @@ import click
 
 from synapto import __version__
 
+logger = logging.getLogger("synapto.cli")
+
+# Memory migration: how many texts to embed per provider call.
+EMBEDDING_BATCH_SIZE = 64
+
 
 def _run(coro):
     """Run an async function synchronously."""
@@ -621,7 +626,6 @@ def migrate_memories(dry_run: bool, home: str | None) -> None:
     from pathlib import Path
 
     from synapto.migration.detect import detect_all
-    from synapto.migration.parse import parse_memory_file, parse_memory_index, parse_transcript
 
     scan_home = Path(home) if home else None
     result = detect_all(scan_home)
@@ -667,17 +671,15 @@ def migrate_memories(dry_run: bool, home: str | None) -> None:
         return
 
     async def _do_import():
+        from datetime import datetime, timezone
+
         from psycopg.types.json import Jsonb
 
         from synapto.config import load_config
         from synapto.db.migrations import ensure_hnsw_index, run_migrations
         from synapto.db.postgres import PostgresClient
         from synapto.embeddings.registry import get_provider
-        from synapto.graph.entities import create_entity, extract_entities_from_text
-        from synapto.graph.relations import create_relation_by_name
-        from synapto.repositories.entities import EntityRepository
         from synapto.repositories.memories import MemoryRepository
-        from synapto.repositories.relations import RelationRepository
 
         config = load_config()
         client = PostgresClient(config.pg_dsn)
@@ -688,38 +690,64 @@ def migrate_memories(dry_run: bool, home: str | None) -> None:
         await ensure_hnsw_index(client, provider.dimension)
 
         mem_repo = MemoryRepository(client)
-        ent_repo = EntityRepository(client)
-        rel_repo = RelationRepository(client)
 
+        # Skip memories whose source file is already in the DB so retries after
+        # a partial run (Ctrl-C, timeout, OOM) don't create duplicates.
+        existing = await mem_repo.find_existing_original_files(config.default_tenant)
+        pending = [
+            m for m in all_parsed
+            if m.metadata.get("original_file") not in existing
+        ]
+        already = len(all_parsed) - len(pending)
+        if already:
+            click.echo(f"  skipping {already} memories already imported")
+
+        if not pending:
+            await client.close()
+            return 0
+
+        migrated_at = datetime.now(timezone.utc).isoformat()
         count = 0
-        for mem in all_parsed:
-            embedding = await provider.embed_one(mem.content)
-            meta = {**mem.metadata, "migrated_at": "auto"}
-            memory_id = await mem_repo.create(
-                content=mem.content,
-                embedding=embedding,
-                embedding_dim=provider.dimension,
-                memory_type=mem.memory_type,
-                tenant=config.default_tenant,
-                depth_layer=mem.depth_layer,
-                summary=mem.summary,
-                metadata=meta,
-            )
 
-            # extract and link entities
-            entities = extract_entities_from_text(mem.content)
-            for ent_name, ent_type in entities:
-                ent_id = await create_entity(ent_repo, ent_name, ent_type, config.default_tenant)
-                await create_relation_by_name(
-                    rel_repo, ent_repo,
-                    source_name=str(memory_id), source_type="memory",
-                    target_name=ent_name, target_type=ent_type,
-                    relation_type="mentions", tenant=config.default_tenant,
-                )
+        # Embed in batches — one provider round-trip per N texts instead of per memory.
+        for batch_start in range(0, len(pending), EMBEDDING_BATCH_SIZE):
+            batch = pending[batch_start:batch_start + EMBEDDING_BATCH_SIZE]
+            embeddings = await provider.embed([m.content for m in batch])
 
-            count += 1
-            if count % 10 == 0:
-                click.echo(f"  [{count}/{len(all_parsed)}] importing...")
+            for mem, embedding in zip(batch, embeddings):
+                meta = {**mem.metadata, "migrated_at": migrated_at}
+                try:
+                    async with client.acquire() as conn:
+                        async with conn.transaction():
+                            await conn.execute(
+                                """
+                                INSERT INTO memories
+                                    (content, summary, embedding, embedding_dim,
+                                     type, tenant, depth_layer, metadata)
+                                VALUES (%s, %s, %s, %s, %s, %s, %s, %s);
+                                """,
+                                (
+                                    mem.content,
+                                    mem.summary,
+                                    embedding,
+                                    provider.dimension,
+                                    mem.memory_type,
+                                    config.default_tenant,
+                                    mem.depth_layer,
+                                    Jsonb(meta),
+                                ),
+                            )
+                except Exception as exc:
+                    logger.warning(
+                        "failed to import %s: %s",
+                        mem.metadata.get("original_file", "?"),
+                        exc,
+                    )
+                    continue
+
+                count += 1
+                if count % 10 == 0:
+                    click.echo(f"  [{count}/{len(pending)}] importing...")
 
         await client.close()
         return count

--- a/src/synapto/cli.py
+++ b/src/synapto/cli.py
@@ -89,6 +89,9 @@ def init(pg_dsn: str, interactive: bool) -> None:
         # offer to write MCP client config
         _offer_mcp_config(tenant)
 
+        # memory migration
+        _offer_memory_migration()
+
         # summary
         click.echo("\n--- setup complete ---")
         click.echo(f"  postgresql: {pg_dsn}")
@@ -581,6 +584,176 @@ def _offer_mcp_config(tenant: str = "default") -> None:
             click.echo(f"  written: {client['path']}")
         else:
             click.echo(f"  skipped: {client['name']}")
+
+
+def _offer_memory_migration() -> None:
+    """Scan for existing AI agent memories and offer to preview the results."""
+    from synapto.migration.detect import detect_all
+
+    click.echo("\n--- memory migration ---")
+    click.echo("scanning for existing memories...")
+
+    result = detect_all()
+    if not result.sources:
+        click.echo("no existing memories found")
+        return
+
+    by_client = result.by_client()
+    for client_name, sources in by_client.items():
+        click.echo(f"\n  {client_name}:")
+        for src in sources[:10]:
+            label = f"({src.format})"
+            if src.estimated_count > 1:
+                label += f" ~{src.estimated_count} entries"
+            click.echo(f"    {src.path} {label}")
+        if len(sources) > 10:
+            click.echo(f"    ... and {len(sources) - 10} more")
+
+    click.echo(f"\nfound {len(result.sources)} sources (~{result.total_estimated} estimated memories)")
+    click.echo("run 'synapto migrate-memories' to import them.")
+
+
+@main.command(name="migrate-memories")
+@click.option("--dry-run", is_flag=True, help="preview without importing")
+@click.option("--home", default=None, type=click.Path(exists=True), help="override home directory for scanning")
+def migrate_memories(dry_run: bool, home: str | None) -> None:
+    """Detect and import existing AI agent memories."""
+    from pathlib import Path
+
+    from synapto.migration.detect import detect_all
+    from synapto.migration.parse import parse_memory_file, parse_memory_index, parse_transcript
+
+    scan_home = Path(home) if home else None
+    result = detect_all(scan_home)
+
+    if not result.sources:
+        click.echo("no existing memories found")
+        return
+
+    by_client = result.by_client()
+    for client_name, sources in by_client.items():
+        click.echo(f"\n  {client_name}:")
+        for src in sources:
+            label = f"({src.format})"
+            if src.estimated_count > 1:
+                label += f" ~{src.estimated_count} entries"
+            click.echo(f"    {src.path} {label}")
+
+    click.echo(f"\nfound {len(result.sources)} sources (~{result.total_estimated} estimated memories)")
+
+    if dry_run:
+        # parse and show what would be imported
+        all_parsed = _parse_all_sources(result.sources)
+        click.echo(f"\nwould import {len(all_parsed)} memories:")
+        by_type: dict[str, int] = {}
+        by_depth: dict[str, int] = {}
+        for mem in all_parsed:
+            by_type[mem.memory_type] = by_type.get(mem.memory_type, 0) + 1
+            by_depth[mem.depth_layer] = by_depth.get(mem.depth_layer, 0) + 1
+        for t, c in sorted(by_type.items()):
+            click.echo(f"  {t}: {c}")
+        click.echo("by depth layer:")
+        for d, c in sorted(by_depth.items()):
+            click.echo(f"  {d}: {c}")
+        return
+
+    if not click.confirm("migrate these memories to synapto?", default=True):
+        click.echo("migration cancelled")
+        return
+
+    all_parsed = _parse_all_sources(result.sources)
+    if not all_parsed:
+        click.echo("no memories could be parsed from the detected sources")
+        return
+
+    async def _do_import():
+        from psycopg.types.json import Jsonb
+
+        from synapto.config import load_config
+        from synapto.db.migrations import ensure_hnsw_index, run_migrations
+        from synapto.db.postgres import PostgresClient
+        from synapto.embeddings.registry import get_provider
+        from synapto.graph.entities import create_entity, extract_entities_from_text
+        from synapto.graph.relations import create_relation_by_name
+        from synapto.repositories.entities import EntityRepository
+        from synapto.repositories.memories import MemoryRepository
+        from synapto.repositories.relations import RelationRepository
+
+        config = load_config()
+        client = PostgresClient(config.pg_dsn)
+        await client.connect()
+        await run_migrations(client)
+
+        provider = get_provider(config.embedding_provider)
+        await ensure_hnsw_index(client, provider.dimension)
+
+        mem_repo = MemoryRepository(client)
+        ent_repo = EntityRepository(client)
+        rel_repo = RelationRepository(client)
+
+        count = 0
+        for mem in all_parsed:
+            embedding = await provider.embed_one(mem.content)
+            meta = {**mem.metadata, "migrated_at": "auto"}
+            memory_id = await mem_repo.create(
+                content=mem.content,
+                embedding=embedding,
+                embedding_dim=provider.dimension,
+                memory_type=mem.memory_type,
+                tenant=config.default_tenant,
+                depth_layer=mem.depth_layer,
+                summary=mem.summary,
+                metadata=meta,
+            )
+
+            # extract and link entities
+            entities = extract_entities_from_text(mem.content)
+            for ent_name, ent_type in entities:
+                ent_id = await create_entity(ent_repo, ent_name, ent_type, config.default_tenant)
+                await create_relation_by_name(
+                    rel_repo, ent_repo,
+                    source_name=str(memory_id), source_type="memory",
+                    target_name=ent_name, target_type=ent_type,
+                    relation_type="mentions", tenant=config.default_tenant,
+                )
+
+            count += 1
+            if count % 10 == 0:
+                click.echo(f"  [{count}/{len(all_parsed)}] importing...")
+
+        await client.close()
+        return count
+
+    imported = _run(_do_import())
+    click.echo(f"\nmigrated {imported} memories")
+
+
+def _parse_all_sources(sources) -> list:
+    """Parse all detected sources into ParsedMemory objects."""
+    from synapto.migration.parse import parse_memory_file, parse_memory_index, parse_transcript
+
+    all_parsed = []
+    seen_files: set[str] = set()
+
+    # process indexes first to track which files they cover
+    for src in sources:
+        if src.format == "memory-index":
+            parsed = parse_memory_index(src.path)
+            all_parsed.extend(parsed)
+            # mark linked files as seen
+            for p in parsed:
+                original = p.metadata.get("original_file", "")
+                if original:
+                    seen_files.add(original)
+
+    # then individual files, skipping those already covered by an index
+    for src in sources:
+        if src.format == "memory-file" and str(src.path) not in seen_files:
+            all_parsed.extend(parse_memory_file(src.path))
+        elif src.format == "transcript":
+            all_parsed.extend(parse_transcript(src.path))
+
+    return all_parsed
 
 
 def _parse_markdown_memories(text: str, tenant: str) -> list[dict]:

--- a/src/synapto/migration/__init__.py
+++ b/src/synapto/migration/__init__.py
@@ -1,0 +1,13 @@
+"""Memory migration — auto-detect and import existing memories from other AI coding agents."""
+
+from synapto.migration.detect import detect_all, scan_claude_code_memories, scan_claude_code_transcripts
+from synapto.migration.parse import parse_memory_file, parse_memory_index, parse_transcript
+
+__all__ = [
+    "detect_all",
+    "scan_claude_code_memories",
+    "scan_claude_code_transcripts",
+    "parse_memory_file",
+    "parse_memory_index",
+    "parse_transcript",
+]

--- a/src/synapto/migration/detect.py
+++ b/src/synapto/migration/detect.py
@@ -12,6 +12,8 @@ import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from synapto.migration.parse import INDEX_ENTRY_RE
+
 logger = logging.getLogger("synapto.migration.detect")
 
 # ---------------------------------------------------------------------------
@@ -75,12 +77,16 @@ def _has_memory_frontmatter(path: Path) -> bool:
 
 
 def _count_index_entries(index_path: Path) -> int:
-    """Count linkable entries in a MEMORY.md index file."""
+    """Count linkable entries in a MEMORY.md index file.
+
+    Uses the same regex as :data:`synapto.migration.parse.INDEX_ENTRY_RE` so the
+    detection estimate matches the number the parser will actually import.
+    """
     try:
         text = index_path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return 0
-    return sum(1 for line in text.split("\n") if line.strip().startswith("- ["))
+    return sum(1 for line in text.split("\n") if INDEX_ENTRY_RE.match(line.strip()))
 
 
 def scan_claude_code_memories(home: Path | None = None) -> list[MemorySource]:

--- a/src/synapto/migration/detect.py
+++ b/src/synapto/migration/detect.py
@@ -1,0 +1,219 @@
+"""Scan the environment for existing AI agent memory files.
+
+Implements the detection phase of issue #8: given a home directory, locate memory
+files from Claude Code (memory markdown files and session transcripts) and return
+structured descriptors that the parser can consume.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger("synapto.migration.detect")
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MemorySource:
+    """A detected file that may contain importable memories."""
+
+    path: Path
+    source_client: str
+    format: str
+    estimated_count: int = 1
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class ScanResult:
+    """Aggregated scan output for all detected sources."""
+
+    sources: list[MemorySource] = field(default_factory=list)
+
+    @property
+    def total_estimated(self) -> int:
+        return sum(s.estimated_count for s in self.sources)
+
+    def by_client(self) -> dict[str, list[MemorySource]]:
+        groups: dict[str, list[MemorySource]] = {}
+        for s in self.sources:
+            groups.setdefault(s.source_client, []).append(s)
+        return groups
+
+
+# ---------------------------------------------------------------------------
+# Claude Code — memory files (~/.claude/projects/*/memory/*.md)
+# ---------------------------------------------------------------------------
+
+_FRONTMATTER_FENCE = "---"
+_REQUIRED_FRONTMATTER_KEYS = {"name", "type"}
+
+
+def _has_memory_frontmatter(path: Path) -> bool:
+    """Return True if *path* starts with YAML frontmatter containing memory keys."""
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+
+    lines = text.split("\n")
+    if not lines or lines[0].strip() != _FRONTMATTER_FENCE:
+        return False
+
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == _FRONTMATTER_FENCE:
+            header_block = "\n".join(lines[1:i])
+            keys = {part.split(":")[0].strip() for part in header_block.split("\n") if ":" in part}
+            return _REQUIRED_FRONTMATTER_KEYS.issubset(keys)
+    return False
+
+
+def _count_index_entries(index_path: Path) -> int:
+    """Count linkable entries in a MEMORY.md index file."""
+    try:
+        text = index_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return 0
+    return sum(1 for line in text.split("\n") if line.strip().startswith("- ["))
+
+
+def scan_claude_code_memories(home: Path | None = None) -> list[MemorySource]:
+    """Scan ``~/.claude/projects/*/memory/`` for memory markdown files.
+
+    Returns one :class:`MemorySource` per file.  For ``MEMORY.md`` index files the
+    ``estimated_count`` reflects the number of linked sections rather than 1.
+    """
+    root = (home or Path.home()) / ".claude" / "projects"
+    if not root.is_dir():
+        logger.debug("claude code projects dir not found: %s", root)
+        return []
+
+    sources: list[MemorySource] = []
+    for memory_dir in root.glob("*/memory"):
+        if not memory_dir.is_dir():
+            continue
+
+        project_slug = memory_dir.parent.name
+
+        for md in sorted(memory_dir.glob("*.md")):
+            if md.name == "MEMORY.md":
+                count = _count_index_entries(md)
+                if count > 0:
+                    sources.append(
+                        MemorySource(
+                            path=md,
+                            source_client="claude-code",
+                            format="memory-index",
+                            estimated_count=count,
+                            metadata={"project": project_slug},
+                        )
+                    )
+            elif _has_memory_frontmatter(md):
+                sources.append(
+                    MemorySource(
+                        path=md,
+                        source_client="claude-code",
+                        format="memory-file",
+                        estimated_count=1,
+                        metadata={"project": project_slug},
+                    )
+                )
+
+    logger.info("claude code memories: found %d files", len(sources))
+    return sources
+
+
+# ---------------------------------------------------------------------------
+# Claude Code — transcripts (~/.claude/projects/*/*.jsonl)
+# ---------------------------------------------------------------------------
+
+_MIN_USER_MESSAGES = 3
+
+
+def _is_transcript(path: Path) -> tuple[bool, int]:
+    """Check if *path* looks like a Claude Code session transcript.
+
+    Returns ``(is_valid, user_message_count)``.  A transcript is valid when it
+    contains JSON objects with ``"type"`` fields matching known message roles and
+    has at least :data:`_MIN_USER_MESSAGES` user turns.
+    """
+    user_count = 0
+    has_assistant = False
+    try:
+        with path.open(encoding="utf-8", errors="replace") as fh:
+            for i, line in enumerate(fh):
+                if i > 500:
+                    break
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                msg_type = obj.get("type", "")
+                if msg_type == "user":
+                    user_count += 1
+                elif msg_type == "assistant":
+                    has_assistant = True
+    except OSError:
+        return False, 0
+
+    return (user_count >= _MIN_USER_MESSAGES and has_assistant), user_count
+
+
+def scan_claude_code_transcripts(home: Path | None = None) -> list[MemorySource]:
+    """Scan ``~/.claude/projects/*/`` for session transcript ``.jsonl`` files.
+
+    Only files with at least :data:`_MIN_USER_MESSAGES` user messages are included.
+    """
+    root = (home or Path.home()) / ".claude" / "projects"
+    if not root.is_dir():
+        logger.debug("claude code projects dir not found: %s", root)
+        return []
+
+    sources: list[MemorySource] = []
+    for project_dir in sorted(root.iterdir()):
+        if not project_dir.is_dir():
+            continue
+        project_slug = project_dir.name
+        for jsonl in sorted(project_dir.glob("*.jsonl")):
+            valid, user_count = _is_transcript(jsonl)
+            if valid:
+                sources.append(
+                    MemorySource(
+                        path=jsonl,
+                        source_client="claude-code",
+                        format="transcript",
+                        estimated_count=user_count,
+                        metadata={"project": project_slug},
+                    )
+                )
+
+    logger.info("claude code transcripts: found %d files", len(sources))
+    return sources
+
+
+# ---------------------------------------------------------------------------
+# Aggregate scanner
+# ---------------------------------------------------------------------------
+
+
+def detect_all(home: Path | None = None) -> ScanResult:
+    """Run all available scanners and return a combined :class:`ScanResult`."""
+    sources: list[MemorySource] = []
+    sources.extend(scan_claude_code_memories(home))
+    sources.extend(scan_claude_code_transcripts(home))
+    result = ScanResult(sources=sources)
+    logger.info(
+        "detection complete: %d sources, ~%d estimated memories",
+        len(result.sources),
+        result.total_estimated,
+    )
+    return result

--- a/src/synapto/migration/parse.py
+++ b/src/synapto/migration/parse.py
@@ -1,0 +1,273 @@
+"""Parse detected memory sources into structured records ready for import.
+
+Each parser accepts a file path and returns a list of :class:`ParsedMemory` objects
+that can be passed directly to :func:`synapto.server.remember` (or the equivalent
+repository call) for storage.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger("synapto.migration.parse")
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+# Mapping from Claude Code memory type to Synapto depth layer.
+TYPE_TO_DEPTH: dict[str, str] = {
+    "user": "core",
+    "feedback": "core",
+    "project": "working",
+    "reference": "stable",
+}
+
+DEFAULT_DEPTH = "working"
+
+
+@dataclass
+class ParsedMemory:
+    """A single memory record extracted from a source file."""
+
+    content: str
+    memory_type: str = "general"
+    depth_layer: str = DEFAULT_DEPTH
+    summary: str | None = None
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# YAML frontmatter helpers (minimal — avoids PyYAML dependency)
+# ---------------------------------------------------------------------------
+
+_FM_FENCE = "---"
+_KV_RE = re.compile(r"^(\w[\w_-]*)\s*:\s*(.+)$")
+
+
+def _parse_frontmatter(text: str) -> tuple[dict[str, str], str]:
+    """Extract key-value pairs from ``---`` fenced YAML frontmatter.
+
+    Returns ``(frontmatter_dict, body)`` where *body* is everything after the
+    closing fence.  If no valid frontmatter is found, returns ``({}, text)``.
+    """
+    lines = text.split("\n")
+    if not lines or lines[0].strip() != _FM_FENCE:
+        return {}, text
+
+    fm: dict[str, str] = {}
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == _FM_FENCE:
+            body = "\n".join(lines[i + 1 :]).strip()
+            return fm, body
+        match = _KV_RE.match(line.strip())
+        if match:
+            fm[match.group(1).lower()] = match.group(2).strip()
+
+    return {}, text
+
+
+# ---------------------------------------------------------------------------
+# Claude Code — individual memory files
+# ---------------------------------------------------------------------------
+
+
+def parse_memory_file(path: Path) -> list[ParsedMemory]:
+    """Parse a Claude Code memory ``.md`` file with YAML frontmatter.
+
+    Expected format::
+
+        ---
+        name: some name
+        description: one-line description
+        type: user | feedback | project | reference
+        ---
+
+        Memory content here...
+    """
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        logger.warning("cannot read %s: %s", path, exc)
+        return []
+
+    fm, body = _parse_frontmatter(text)
+    if not body.strip():
+        return []
+
+    memory_type = fm.get("type", "general")
+    depth = TYPE_TO_DEPTH.get(memory_type, DEFAULT_DEPTH)
+    name = fm.get("name", path.stem)
+    description = fm.get("description", "")
+
+    return [
+        ParsedMemory(
+            content=body,
+            memory_type=memory_type,
+            depth_layer=depth,
+            summary=description or None,
+            metadata={
+                "source": "claude-code",
+                "original_file": str(path),
+                "original_name": name,
+            },
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Claude Code — MEMORY.md index
+# ---------------------------------------------------------------------------
+
+_INDEX_ENTRY_RE = re.compile(r"^-\s+\[([^\]]+)\]\(([^)]+)\)\s*(?:—\s*(.+))?$")
+
+
+def parse_memory_index(path: Path) -> list[ParsedMemory]:
+    """Parse a Claude Code ``MEMORY.md`` index and resolve linked files.
+
+    Each ``- [Title](file.md) — description`` entry is resolved relative to the
+    index file's directory.  If the linked file has frontmatter it is parsed via
+    :func:`parse_memory_file`; otherwise the raw content is imported as-is.
+    """
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        logger.warning("cannot read index %s: %s", path, exc)
+        return []
+
+    results: list[ParsedMemory] = []
+    parent = path.parent
+
+    for line in text.split("\n"):
+        match = _INDEX_ENTRY_RE.match(line.strip())
+        if not match:
+            continue
+
+        title, rel_path, description = match.group(1), match.group(2), match.group(3)
+        linked = parent / rel_path
+        if not linked.is_file():
+            logger.debug("linked file not found: %s", linked)
+            continue
+
+        parsed = parse_memory_file(linked)
+        if parsed:
+            for mem in parsed:
+                if mem.summary is None and description:
+                    mem.summary = description.strip()
+            results.extend(parsed)
+        else:
+            # fallback: import raw content with metadata from the index entry
+            try:
+                content = linked.read_text(encoding="utf-8", errors="replace").strip()
+            except OSError:
+                continue
+            if content:
+                results.append(
+                    ParsedMemory(
+                        content=content,
+                        memory_type="general",
+                        depth_layer=DEFAULT_DEPTH,
+                        summary=description.strip() if description else None,
+                        metadata={
+                            "source": "claude-code",
+                            "original_file": str(linked),
+                            "original_name": title,
+                        },
+                    )
+                )
+
+    logger.info("parsed %d memories from index %s", len(results), path)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Claude Code — session transcripts
+# ---------------------------------------------------------------------------
+
+_SUMMARY_MAX_LEN = 200
+
+
+def parse_transcript(path: Path, max_messages: int = 50) -> list[ParsedMemory]:
+    """Extract importable memories from a Claude Code session transcript.
+
+    The transcript is a ``.jsonl`` file where each line is a JSON object with a
+    ``type`` field (``"user"`` or ``"assistant"``).  We extract user messages as
+    potential memories — the user's instructions, corrections, and context are
+    the most valuable part of a session transcript.
+
+    Only the first *max_messages* user messages are processed to keep import
+    sizes reasonable.
+
+    Each message becomes a separate ``ParsedMemory`` with ``depth_layer="working"``
+    (transcripts are typically session-scoped, not permanent).
+    """
+    results: list[ParsedMemory] = []
+    try:
+        with path.open(encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+
+                if obj.get("type") != "user":
+                    continue
+
+                content = _extract_message_content(obj)
+                if not content or len(content) < 20:
+                    continue
+
+                summary = content[:_SUMMARY_MAX_LEN] + ("..." if len(content) > _SUMMARY_MAX_LEN else "")
+                results.append(
+                    ParsedMemory(
+                        content=content,
+                        memory_type="project",
+                        depth_layer="working",
+                        summary=summary,
+                        metadata={
+                            "source": "claude-code-transcript",
+                            "original_file": str(path),
+                        },
+                    )
+                )
+                if len(results) >= max_messages:
+                    break
+    except OSError as exc:
+        logger.warning("cannot read transcript %s: %s", path, exc)
+
+    logger.info("parsed %d messages from transcript %s", len(results), path)
+    return results
+
+
+def _extract_message_content(obj: dict) -> str:
+    """Pull readable text from a transcript message object.
+
+    Handles both flat ``{"message": "..."}`` and nested ``{"message":
+    {"content": [{"type": "text", "text": "..."}]}}`` shapes.
+    """
+    msg = obj.get("message", "")
+    if isinstance(msg, str):
+        return msg.strip()
+
+    if isinstance(msg, dict):
+        # {"content": "text"} or {"content": [{"type": "text", "text": "..."}]}
+        content = msg.get("content", "")
+        if isinstance(content, str):
+            return content.strip()
+        if isinstance(content, list):
+            parts = []
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    parts.append(block.get("text", ""))
+                elif isinstance(block, str):
+                    parts.append(block)
+            return "\n".join(parts).strip()
+
+    return ""

--- a/src/synapto/migration/parse.py
+++ b/src/synapto/migration/parse.py
@@ -123,7 +123,10 @@ def parse_memory_file(path: Path) -> list[ParsedMemory]:
 # Claude Code — MEMORY.md index
 # ---------------------------------------------------------------------------
 
-_INDEX_ENTRY_RE = re.compile(r"^-\s+\[([^\]]+)\]\(([^)]+)\)\s*(?:—\s*(.+))?$")
+# Match a MEMORY.md index entry: ``- [Title](file.md) — description``.
+# The separator before the description may be an em dash (U+2014), an en dash
+# (U+2013), or an ASCII hyphen, since editors and AI agents normalize differently.
+INDEX_ENTRY_RE = re.compile(r"^-\s+\[([^\]]+)\]\(([^)]+)\)\s*(?:[—–-]\s*(.+))?$")
 
 
 def parse_memory_index(path: Path) -> list[ParsedMemory]:
@@ -143,7 +146,7 @@ def parse_memory_index(path: Path) -> list[ParsedMemory]:
     parent = path.parent
 
     for line in text.split("\n"):
-        match = _INDEX_ENTRY_RE.match(line.strip())
+        match = INDEX_ENTRY_RE.match(line.strip())
         if not match:
             continue
 

--- a/src/synapto/repositories/memories.py
+++ b/src/synapto/repositories/memories.py
@@ -95,6 +95,14 @@ _COUNT_BY_TENANT = """
     {where_clause} GROUP BY tenant ORDER BY cnt DESC;
 """
 
+_SELECT_ORIGINAL_FILES = """
+    SELECT metadata->>'original_file' AS original_file
+    FROM memories
+    WHERE tenant = %s
+      AND deleted_at IS NULL
+      AND metadata ? 'original_file';
+"""
+
 
 # ---------------------------------------------------------------------------
 # Repository
@@ -196,6 +204,10 @@ class MemoryRepository:
     async def count_by_tenant(self, tenant: str | None = None) -> list[dict]:
         where, params = self._tenant_filter(tenant)
         return await self._db.execute(_COUNT_BY_TENANT.format(where_clause=where), params)
+
+    async def find_existing_original_files(self, tenant: str) -> set[str]:
+        rows = await self._db.execute(_SELECT_ORIGINAL_FILES, (tenant,))
+        return {r["original_file"] for r in rows if r.get("original_file")}
 
     @staticmethod
     def _tenant_filter(tenant: str | None) -> tuple[str, tuple]:

--- a/tests/unit/test_migration_detect.py
+++ b/tests/unit/test_migration_detect.py
@@ -1,0 +1,147 @@
+"""Tests for memory source detection (issue #8)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from synapto.migration.detect import ScanResult, detect_all, scan_claude_code_memories, scan_claude_code_transcripts
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_memory_file(base: Path, project: str, name: str, fm_type: str = "feedback") -> Path:
+    """Create a Claude Code memory .md file with frontmatter."""
+    mem_dir = base / ".claude" / "projects" / project / "memory"
+    mem_dir.mkdir(parents=True, exist_ok=True)
+    path = mem_dir / name
+    path.write_text(
+        f"---\nname: {name.replace('.md', '')}\ndescription: test memory\ntype: {fm_type}\n---\n\nSome content here.\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _make_memory_index(base: Path, project: str, entries: list[str]) -> Path:
+    """Create a MEMORY.md index linking to the given file names."""
+    mem_dir = base / ".claude" / "projects" / project / "memory"
+    mem_dir.mkdir(parents=True, exist_ok=True)
+    lines = [f"- [{e.replace('.md', '')}]({e}) — description for {e}" for e in entries]
+    path = mem_dir / "MEMORY.md"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def _make_transcript(base: Path, project: str, name: str, user_count: int = 5) -> Path:
+    """Create a minimal Claude Code session transcript."""
+    proj_dir = base / ".claude" / "projects" / project
+    proj_dir.mkdir(parents=True, exist_ok=True)
+    path = proj_dir / name
+    lines = []
+    for i in range(user_count):
+        msg = f"user message number {i} with enough length to pass the threshold"
+        lines.append(json.dumps({"type": "user", "message": msg}))
+        lines.append(json.dumps({"type": "assistant", "message": f"assistant reply {i}"}))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# scan_claude_code_memories
+# ---------------------------------------------------------------------------
+
+
+def test_scan_memories_finds_files_with_frontmatter(tmp_path: Path) -> None:
+    _make_memory_file(tmp_path, "proj-a", "feedback_style.md", "feedback")
+    _make_memory_file(tmp_path, "proj-a", "project_state.md", "project")
+
+    sources = scan_claude_code_memories(tmp_path)
+    assert len(sources) == 2
+    assert all(s.source_client == "claude-code" for s in sources)
+    assert all(s.format == "memory-file" for s in sources)
+
+
+def test_scan_memories_skips_files_without_frontmatter(tmp_path: Path) -> None:
+    mem_dir = tmp_path / ".claude" / "projects" / "proj-a" / "memory"
+    mem_dir.mkdir(parents=True)
+    (mem_dir / "random.md").write_text("# Just a heading\n\nNo frontmatter here.\n")
+
+    sources = scan_claude_code_memories(tmp_path)
+    assert len(sources) == 0
+
+
+def test_scan_memories_detects_index(tmp_path: Path) -> None:
+    _make_memory_file(tmp_path, "proj-a", "fb.md", "feedback")
+    _make_memory_index(tmp_path, "proj-a", ["fb.md", "missing.md"])
+
+    sources = scan_claude_code_memories(tmp_path)
+    index_sources = [s for s in sources if s.format == "memory-index"]
+    assert len(index_sources) == 1
+    assert index_sources[0].estimated_count == 2
+
+
+def test_scan_memories_empty_when_no_claude_dir(tmp_path: Path) -> None:
+    sources = scan_claude_code_memories(tmp_path)
+    assert sources == []
+
+
+def test_scan_memories_extracts_project_slug(tmp_path: Path) -> None:
+    _make_memory_file(tmp_path, "-Users-ramon-myproject", "ref.md", "reference")
+
+    sources = scan_claude_code_memories(tmp_path)
+    assert len(sources) == 1
+    assert sources[0].metadata["project"] == "-Users-ramon-myproject"
+
+
+# ---------------------------------------------------------------------------
+# scan_claude_code_transcripts
+# ---------------------------------------------------------------------------
+
+
+def test_scan_transcripts_finds_valid_sessions(tmp_path: Path) -> None:
+    _make_transcript(tmp_path, "proj-a", "session_001.jsonl", user_count=5)
+
+    sources = scan_claude_code_transcripts(tmp_path)
+    assert len(sources) == 1
+    assert sources[0].format == "transcript"
+    assert sources[0].estimated_count == 5
+
+
+def test_scan_transcripts_skips_short_sessions(tmp_path: Path) -> None:
+    _make_transcript(tmp_path, "proj-a", "tiny.jsonl", user_count=1)
+
+    sources = scan_claude_code_transcripts(tmp_path)
+    assert len(sources) == 0
+
+
+def test_scan_transcripts_skips_non_jsonl(tmp_path: Path) -> None:
+    proj_dir = tmp_path / ".claude" / "projects" / "proj-a"
+    proj_dir.mkdir(parents=True)
+    (proj_dir / "notes.txt").write_text("not a transcript")
+
+    sources = scan_claude_code_transcripts(tmp_path)
+    assert len(sources) == 0
+
+
+# ---------------------------------------------------------------------------
+# detect_all
+# ---------------------------------------------------------------------------
+
+
+def test_detect_all_combines_sources(tmp_path: Path) -> None:
+    _make_memory_file(tmp_path, "proj-a", "fb.md", "feedback")
+    _make_transcript(tmp_path, "proj-a", "session.jsonl", user_count=4)
+
+    result = detect_all(tmp_path)
+    assert isinstance(result, ScanResult)
+    assert len(result.sources) == 2
+    by_client = result.by_client()
+    assert "claude-code" in by_client
+
+
+def test_detect_all_empty_home(tmp_path: Path) -> None:
+    result = detect_all(tmp_path)
+    assert result.sources == []
+    assert result.total_estimated == 0

--- a/tests/unit/test_migration_parse.py
+++ b/tests/unit/test_migration_parse.py
@@ -1,0 +1,188 @@
+"""Tests for memory source parsing (issue #8)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from synapto.migration.parse import parse_memory_file, parse_memory_index, parse_transcript
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# parse_memory_file
+# ---------------------------------------------------------------------------
+
+
+def test_parse_memory_file_extracts_frontmatter(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path / "feedback_style.md",
+        "---\nname: code readability\ndescription: always do a readability pass\n"
+        "type: feedback\n---\n\nAfter completing any implementation, review for readability.\n",
+    )
+
+    results = parse_memory_file(path)
+    assert len(results) == 1
+    mem = results[0]
+    assert mem.memory_type == "feedback"
+    assert mem.depth_layer == "core"
+    assert mem.summary == "always do a readability pass"
+    assert "readability" in mem.content
+    assert mem.metadata["source"] == "claude-code"
+    assert mem.metadata["original_name"] == "code readability"
+
+
+def test_parse_memory_file_maps_types_to_depth(tmp_path: Path) -> None:
+    type_depth_map = [("user", "core"), ("feedback", "core"), ("project", "working"), ("reference", "stable")]
+    for mem_type, expected_depth in type_depth_map:
+        path = _write(
+            tmp_path / f"{mem_type}.md",
+            f"---\nname: test\ntype: {mem_type}\n---\n\ncontent\n",
+        )
+        results = parse_memory_file(path)
+        assert results[0].depth_layer == expected_depth, f"type={mem_type} should map to depth={expected_depth}"
+
+
+def test_parse_memory_file_skips_empty_body(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path / "empty.md",
+        "---\nname: empty\ntype: feedback\n---\n\n",
+    )
+    assert parse_memory_file(path) == []
+
+
+def test_parse_memory_file_no_frontmatter(tmp_path: Path) -> None:
+    path = _write(tmp_path / "plain.md", "# Just a heading\n\nSome text.")
+    results = parse_memory_file(path)
+    assert len(results) == 1
+    assert results[0].memory_type == "general"
+    assert results[0].depth_layer == "working"
+
+
+def test_parse_memory_file_missing_file(tmp_path: Path) -> None:
+    assert parse_memory_file(tmp_path / "nonexistent.md") == []
+
+
+# ---------------------------------------------------------------------------
+# parse_memory_index
+# ---------------------------------------------------------------------------
+
+
+def test_parse_memory_index_resolves_linked_files(tmp_path: Path) -> None:
+    _write(
+        tmp_path / "feedback_style.md",
+        "---\nname: style\ndescription: style guide\ntype: feedback\n---\n\nUse consistent naming.\n",
+    )
+    _write(
+        tmp_path / "ref_db.md",
+        "---\nname: databases\ndescription: prod db list\ntype: reference\n---\n\nPostgres on port 5432.\n",
+    )
+    index = _write(
+        tmp_path / "MEMORY.md",
+        "- [Style Guide](feedback_style.md) — coding style\n- [Databases](ref_db.md) — production databases\n",
+    )
+
+    results = parse_memory_index(index)
+    assert len(results) == 2
+    types = {r.memory_type for r in results}
+    assert types == {"feedback", "reference"}
+
+
+def test_parse_memory_index_skips_missing_links(tmp_path: Path) -> None:
+    index = _write(
+        tmp_path / "MEMORY.md",
+        "- [Gone](deleted.md) — this file does not exist\n",
+    )
+    assert parse_memory_index(index) == []
+
+
+def test_parse_memory_index_fallback_for_raw_files(tmp_path: Path) -> None:
+    _write(tmp_path / "notes.md", "Some raw notes without frontmatter.")
+    index = _write(tmp_path / "MEMORY.md", "- [Notes](notes.md) — random notes\n")
+
+    results = parse_memory_index(index)
+    assert len(results) == 1
+    assert results[0].memory_type == "general"
+    assert results[0].summary == "random notes"
+
+
+# ---------------------------------------------------------------------------
+# parse_transcript
+# ---------------------------------------------------------------------------
+
+
+def _make_transcript_file(path: Path, messages: list[dict]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(m) for m in messages) + "\n", encoding="utf-8")
+    return path
+
+
+def test_parse_transcript_extracts_user_messages(tmp_path: Path) -> None:
+    msgs = [
+        {"type": "user", "message": "fix the authentication bug in login.py please"},
+        {"type": "assistant", "message": "I'll look at login.py now."},
+        {"type": "user", "message": "also check the session timeout handling while you're at it"},
+        {"type": "assistant", "message": "Found the issue in both places."},
+    ]
+    path = _make_transcript_file(tmp_path / "session.jsonl", msgs)
+
+    results = parse_transcript(path)
+    assert len(results) == 2
+    assert all(r.memory_type == "project" for r in results)
+    assert all(r.depth_layer == "working" for r in results)
+    assert "authentication" in results[0].content
+
+
+def test_parse_transcript_skips_short_messages(tmp_path: Path) -> None:
+    msgs = [
+        {"type": "user", "message": "yes"},
+        {"type": "assistant", "message": "ok"},
+        {"type": "user", "message": "a message that is long enough to be meaningful for import"},
+    ]
+    path = _make_transcript_file(tmp_path / "session.jsonl", msgs)
+
+    results = parse_transcript(path)
+    assert len(results) == 1
+
+
+def test_parse_transcript_handles_nested_content(tmp_path: Path) -> None:
+    msgs = [
+        {
+            "type": "user",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "please review the database migration script carefully"},
+                ]
+            },
+        },
+        {"type": "assistant", "message": "reviewing now"},
+    ]
+    path = _make_transcript_file(tmp_path / "session.jsonl", msgs)
+
+    results = parse_transcript(path)
+    assert len(results) == 1
+    assert "database migration" in results[0].content
+
+
+def test_parse_transcript_respects_max_messages(tmp_path: Path) -> None:
+    msgs = []
+    for i in range(100):
+        msgs.append({"type": "user", "message": f"user message number {i} with sufficient length to pass threshold"})
+        msgs.append({"type": "assistant", "message": f"reply {i}"})
+    path = _make_transcript_file(tmp_path / "session.jsonl", msgs)
+
+    results = parse_transcript(path, max_messages=10)
+    assert len(results) == 10
+
+
+def test_parse_transcript_missing_file(tmp_path: Path) -> None:
+    assert parse_transcript(tmp_path / "nonexistent.jsonl") == []

--- a/tests/unit/test_migration_parse.py
+++ b/tests/unit/test_migration_parse.py
@@ -105,6 +105,35 @@ def test_parse_memory_index_skips_missing_links(tmp_path: Path) -> None:
     assert parse_memory_index(index) == []
 
 
+def test_parse_memory_index_accepts_ascii_and_en_dash(tmp_path: Path) -> None:
+    """The index regex must accept em dash (—), en dash (–), and ASCII hyphen (-)."""
+    _write(
+        tmp_path / "em.md",
+        "---\nname: em\ndescription: em-dash entry\ntype: feedback\n---\n\nem dash content.\n",
+    )
+    _write(
+        tmp_path / "en.md",
+        "---\nname: en\ndescription: en-dash entry\ntype: feedback\n---\n\nen dash content.\n",
+    )
+    _write(
+        tmp_path / "ascii.md",
+        "---\nname: ascii\ndescription: ascii-hyphen entry\ntype: feedback\n---\n\nascii hyphen content.\n",
+    )
+    index = _write(
+        tmp_path / "MEMORY.md",
+        "- [Em](em.md) — em dash here\n"
+        "- [En](en.md) – en dash here\n"
+        "- [Ascii](ascii.md) - ascii hyphen here\n",
+    )
+
+    results = parse_memory_index(index)
+    assert len(results) == 3
+    contents = {r.content.strip() for r in results}
+    assert any("em dash" in c for c in contents)
+    assert any("en dash" in c for c in contents)
+    assert any("ascii hyphen" in c for c in contents)
+
+
 def test_parse_memory_index_fallback_for_raw_files(tmp_path: Path) -> None:
     _write(tmp_path / "notes.md", "Some raw notes without frontmatter.")
     index = _write(tmp_path / "MEMORY.md", "- [Notes](notes.md) — random notes\n")


### PR DESCRIPTION
## Summary

Implements the detection and parsing phase of #8 — auto-detect existing Claude Code memories and make them available for migration into Synapto.

### What's included

**New `src/synapto/migration/` package:**

- **`detect.py`** — Scans `~/.claude/projects/*/memory/` for memory `.md` files with YAML frontmatter, and `~/.claude/projects/*/*.jsonl` for session transcripts. Returns structured `MemorySource` descriptors with estimated memory counts per file.

- **`parse.py`** — Three parsers:
  - **Memory files**: Extracts content + metadata from `---` fenced YAML frontmatter (`name`, `type`, `description`)
  - **MEMORY.md index**: Resolves `- [Title](file.md) — desc` links, parses each linked file, falls back to raw content import
  - **Session transcripts**: Extracts user messages from `.jsonl` files (handles flat and nested content shapes), skips short messages, caps at configurable max

- **Type → depth layer mapping** from Claude Code conventions to Synapto's model:
  - `user`/`feedback` → `core` (slow decay)
  - `project` → `working` (faster decay)
  - `reference` → `stable` (moderate decay)

**CLI integration:**

- `synapto init --interactive` now scans for existing memories after MCP config and shows a preview
- New `synapto migrate-memories` command with `--dry-run` for preview-only mode

**Tests:** 23 unit tests covering detection, parsing, frontmatter extraction, index resolution, transcript parsing, type mapping, and edge cases. All tests are pure filesystem — no database, Redis, or network required.

### What's NOT included (follow-up)

- Cursor/Windsurf rule file detection (`.cursorrules`, `.windsurfrules`)
- Codex session detection (`~/.codex/sessions/`)
- Cosine similarity dedup at import time (requires DB connection)
- Entity extraction + HRR encoding during migration (wired in CLI but not tested without DB)

### Design decisions

1. **Minimal YAML parser** — avoids adding PyYAML as a dependency; the frontmatter format is simple enough for regex-based key-value extraction.
2. **Index-first parsing** — `MEMORY.md` indexes are processed before individual files to avoid importing duplicates when both the index and the file are detected.
3. **Transcript conservatism** — only user messages are imported (assistant responses are derivative); minimum length threshold (20 chars) filters out "yes"/"ok" messages.

Closes #8 (partial — Claude Code formats; other clients planned as follow-up)
