### PR TITLE
chore(ci): pin pip>=26.1 to fix CVE-2026-3219

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,10 @@ dev = [
     "bandit>=1.7",
     "pip-audit>=2.7",
     "build>=1.0",
+    # pinned to fix CVE-2026-3219 in pip itself; uv bundles 26.0.1 by default
+    # and pip-audit flags it. drop this constraint once uv ships a venv with
+    # pip>=26.1 out of the box.
+    "pip>=26.1",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -1647,11 +1647,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.0.1"
+version = "26.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/7e/d2b04004e1068ad4fdfa2f227b839b5d03e602e47cdbbf49de71137c9546/pip-26.1.tar.gz", hash = "sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3", size = 1840316, upload-time = "2026-04-26T21:00:05.406Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
+    { url = "https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl", hash = "sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1", size = 1812804, upload-time = "2026-04-26T21:00:03.194Z" },
 ]
 
 [[package]]
@@ -2756,6 +2756,7 @@ dependencies = [
 dev = [
     { name = "bandit" },
     { name = "build" },
+    { name = "pip" },
     { name = "pip-audit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -2776,6 +2777,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.24" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0" },
     { name = "pgvector", specifier = ">=0.3.0" },
+    { name = "pip", marker = "extra == 'dev'", specifier = ">=26.1" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.1" },
     { name = "pydantic", specifier = ">=2.0" },


### PR DESCRIPTION
## Summary

The `pip-audit` step in CI started failing on every PR because pip 26.0.1 — which `uv` bundles into the venv by default — has CVE-2026-3219 with no fix-version recorded in the audit DB yet. Latest pip on PyPI is 26.1, and upgrading clears the report locally.

This pins `pip>=26.1` in the `[dev]` extra so the fix is durable and removes the false-positive blocker for unrelated feature PRs (e.g. #29 — telemetry / structured logging).

## Repro

Before:
```
$ uv run pip-audit
Found 1 known vulnerability in 1 package
Name Version ID            Fix Versions
---- ------- ------------- ------------
pip  26.0.1  CVE-2026-3219
```

After (`uv sync --extra dev` with this PR):
```
$ uv run pip-audit
No known vulnerabilities found
```

## Why pin in pyproject

`pip` is not a runtime dependency of Synapto, but it lives inside the venv and `pip-audit` audits everything in the env. Adding it to `[dev]` is the only place we control the version uv installs.

## Removal trigger

Drop the `pip>=26.1` line once `uv` ships a venv with pip>=26.1 out of the box (track via `uv --version` + checking the bundled pip version on a fresh venv).

## Test plan

- [x] `uv sync --extra dev` succeeds
- [x] `uv run pip-audit` reports `No known vulnerabilities found`
- [x] Existing test suite still passes (`uv run pytest tests/ -v` → 122 passed on main + this change)
- [x] CI security job is expected to go green