### PR TITLE
feat(telemetry): metrics registry with log backend (T2 of #9)

### DIFF
--- a/src/synapto/telemetry/__init__.py
+++ b/src/synapto/telemetry/__init__.py
@@ -3,5 +3,23 @@
 from __future__ import annotations
 
 from synapto.telemetry.logging import configure_logging
+from synapto.telemetry.metrics import (
+    LogMetricsBackend,
+    MetricEvent,
+    MetricsBackend,
+    MetricsRegistry,
+    get_registry,
+    measure,
+    set_registry,
+)
 
-__all__ = ["configure_logging"]
+__all__ = [
+    "configure_logging",
+    "get_registry",
+    "set_registry",
+    "measure",
+    "MetricsRegistry",
+    "MetricEvent",
+    "MetricsBackend",
+    "LogMetricsBackend",
+]

--- a/src/synapto/telemetry/metrics.py
+++ b/src/synapto/telemetry/metrics.py
@@ -19,24 +19,39 @@ instrumentation, and the Postgres backend land in later T2/T3/T4/T5/T6 PRs.
 
 from __future__ import annotations
 
+import asyncio
 import time
+from collections.abc import Mapping
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import Any, Literal, Protocol
 
 import structlog
 
 MetricType = Literal["counter", "gauge", "histogram"]
+RESERVED_TAGS: frozenset[str] = frozenset({"outcome"})
 
 
 @dataclass(frozen=True)
 class MetricEvent:
-    """Immutable event passed from registry to backend."""
+    """Immutable event passed from registry to backend.
+
+    ``tags`` is wrapped in a read-only ``MappingProxyType`` after init so a
+    backend cannot mutate the dict in place — frozen=True alone only protects
+    against attribute reassignment.
+    """
 
     name: str
     type: MetricType
     value: float
-    tags: dict[str, Any] = field(default_factory=dict)
+    tags: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        # freeze the tags view; preserves the original dict for the caller while
+        # giving downstream consumers a read-only handle. O(1).
+        if not isinstance(self.tags, MappingProxyType):
+            object.__setattr__(self, "tags", MappingProxyType(dict(self.tags)))
 
 
 class MetricsBackend(Protocol):
@@ -112,24 +127,59 @@ def set_registry(registry: MetricsRegistry | None) -> None:
 
 @asynccontextmanager
 async def measure(name: str, **tags: Any):
-    """Time the wrapped block and emit a histogram with ``outcome=ok|error``.
+    """Time the wrapped block and emit a histogram tagged with the outcome.
 
     Usage:
         async with measure("synapto.recall.total", tenant="acme"):
             await hybrid_search(...)
 
-    On success, emits a histogram event with ``outcome=ok`` and the elapsed
-    milliseconds as the value. On exception, emits with ``outcome=error`` and
-    re-raises — the caller must decide how to handle the failure; the metric
-    is recorded regardless so error-rate dashboards stay accurate.
+    Outcome semantics:
+        - ``outcome=ok``         — block completed without raising.
+        - ``outcome=error``      — block raised a regular ``Exception``.
+        - ``outcome=cancelled``  — block was cancelled via ``asyncio.CancelledError``.
+                                   Cancellation is normal lifecycle in MCP/async
+                                   contexts; tagging it separately keeps error-rate
+                                   dashboards from inflating during graceful shutdown.
+
+    Other ``BaseException`` subclasses (``KeyboardInterrupt``, ``SystemExit``,
+    ``GeneratorExit``) signal interpreter shutdown, not application behaviour;
+    those propagate without emitting a metric so we don't try to record on
+    a tearing-down logger.
+
+    The ``outcome`` tag is reserved — passing it explicitly raises ``ValueError``
+    to avoid the silent ``TypeError: multiple values for keyword argument`` that
+    would otherwise fire from inside a ``finally`` block and mask the real cause.
     """
+    _reject_reserved(tags)
+
     start = time.perf_counter()
-    outcome = "ok"
+    outcome: str | None = None
     try:
         yield
-    except BaseException:
+        outcome = "ok"
+    except asyncio.CancelledError:
+        outcome = "cancelled"
+        raise
+    except Exception:
         outcome = "error"
         raise
     finally:
-        elapsed_ms = (time.perf_counter() - start) * 1000.0
-        get_registry().histogram(name, elapsed_ms, outcome=outcome, **tags)
+        # outcome stays ``None`` for KeyboardInterrupt / SystemExit / GeneratorExit,
+        # which signal interpreter teardown — emitting then risks writing to a
+        # logger that's already being closed.
+        if outcome is not None:
+            elapsed_ms = (time.perf_counter() - start) * 1000.0
+            get_registry().histogram(name, elapsed_ms, outcome=outcome, **tags)
+
+
+def _reject_reserved(tags: Mapping[str, Any]) -> None:
+    """Raise if a caller tries to override a tag managed by ``measure()``.
+
+    O(k) where k = len(RESERVED_TAGS) — small constant.
+    """
+    overlap = RESERVED_TAGS & tags.keys()
+    if overlap:
+        raise ValueError(
+            f"reserved tag(s) cannot be overridden: {sorted(overlap)}; "
+            "measure() manages these automatically"
+        )

--- a/src/synapto/telemetry/metrics.py
+++ b/src/synapto/telemetry/metrics.py
@@ -1,0 +1,135 @@
+"""Metrics primitives — registry facade, pluggable backends, and a timing context manager.
+
+Design patterns:
+    Strategy  -- ``MetricsBackend`` is the strategy contract; backends (log, postgres,
+                 OpenTelemetry) are interchangeable behind it.
+    Adapter   -- Each concrete backend adapts the uniform ``MetricEvent`` interface
+                 to its target sink (structlog logger today, SQL inserts later).
+    Facade    -- ``MetricsRegistry`` exposes ``counter`` / ``gauge`` / ``histogram``
+                 to callers so they never see the event/backend plumbing.
+
+Process-wide singleton via ``get_registry()`` keeps call sites terse; ``set_registry()``
+allows tests and config-driven swaps to replace the backend without touching call
+sites. ``measure()`` is the canonical async timing context manager — it auto-tags
+``outcome=ok`` on success and ``outcome=error`` on exception (and re-raises).
+
+This module deliberately stops at primitives. Per-tool decorators, sub-stage
+instrumentation, and the Postgres backend land in later T2/T3/T4/T5/T6 PRs.
+"""
+
+from __future__ import annotations
+
+import time
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import Any, Literal, Protocol
+
+import structlog
+
+MetricType = Literal["counter", "gauge", "histogram"]
+
+
+@dataclass(frozen=True)
+class MetricEvent:
+    """Immutable event passed from registry to backend."""
+
+    name: str
+    type: MetricType
+    value: float
+    tags: dict[str, Any] = field(default_factory=dict)
+
+
+class MetricsBackend(Protocol):
+    """Strategy contract: emit a metric event to a sink."""
+
+    def emit(self, event: MetricEvent) -> None: ...
+
+
+class LogMetricsBackend:
+    """Adapter that emits each metric as a structured log line via structlog.
+
+    Relies on ``synapto.telemetry.configure_logging`` having installed the JSON
+    renderer at the root handler. Each event becomes one log line:
+
+        {"event": "metric", "metric_name": "...", "metric_type": "...",
+         "value": ..., "<tag_key>": "<tag_value>", ...}
+    """
+
+    def __init__(self) -> None:
+        self._log = structlog.get_logger("synapto.metrics")
+
+    def emit(self, event: MetricEvent) -> None:
+        self._log.info(
+            "metric",
+            metric_name=event.name,
+            metric_type=event.type,
+            value=event.value,
+            **event.tags,
+        )
+
+
+class MetricsRegistry:
+    """Facade for emitting counters, gauges, and histograms through a backend."""
+
+    def __init__(self, backend: MetricsBackend) -> None:
+        self._backend = backend
+
+    def counter(self, name: str, value: float = 1, **tags: Any) -> None:
+        self._backend.emit(MetricEvent(name=name, type="counter", value=float(value), tags=dict(tags)))
+
+    def gauge(self, name: str, value: float, **tags: Any) -> None:
+        self._backend.emit(MetricEvent(name=name, type="gauge", value=float(value), tags=dict(tags)))
+
+    def histogram(self, name: str, value: float, **tags: Any) -> None:
+        self._backend.emit(MetricEvent(name=name, type="histogram", value=float(value), tags=dict(tags)))
+
+
+# ---------------------------------------------------------------------------
+# Singleton plumbing
+# ---------------------------------------------------------------------------
+
+_registry: MetricsRegistry | None = None
+
+
+def get_registry() -> MetricsRegistry:
+    """Return the process-wide registry, lazily creating a default on first use."""
+    global _registry
+    if _registry is None:
+        _registry = MetricsRegistry(backend=LogMetricsBackend())
+    return _registry
+
+
+def set_registry(registry: MetricsRegistry | None) -> None:
+    """Replace the process-wide registry. Pass ``None`` to reset to the default factory."""
+    global _registry
+    _registry = registry
+
+
+# ---------------------------------------------------------------------------
+# measure() — async timing context manager
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def measure(name: str, **tags: Any):
+    """Time the wrapped block and emit a histogram with ``outcome=ok|error``.
+
+    Usage:
+        async with measure("synapto.recall.total", tenant="acme"):
+            await hybrid_search(...)
+
+    On success, emits a histogram event with ``outcome=ok`` and the elapsed
+    milliseconds as the value. On exception, emits with ``outcome=error`` and
+    re-raises — the caller must decide how to handle the failure; the metric
+    is recorded regardless so error-rate dashboards stay accurate.
+    """
+    start = time.perf_counter()
+    outcome = "ok"
+    try:
+        yield
+    except BaseException:
+        outcome = "error"
+        raise
+    finally:
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+        get_registry().histogram(name, elapsed_ms, outcome=outcome, **tags)

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,0 +1,136 @@
+"""Tests for synapto.telemetry.metrics — registry, backends, and measure() context manager.
+
+Validates the contract that:
+- counter/gauge/histogram emit MetricEvent objects to the configured backend
+- measure() async ctx mgr times the block, tags outcome=ok on success and
+  outcome=error on exception (and reraises), and emits a histogram event
+- get_registry returns a singleton; set_registry swaps it (for tests/config)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class RecordingBackend:
+    """Stub backend that captures emitted events for assertion."""
+
+    def __init__(self) -> None:
+        self.events: list = []
+
+    def emit(self, event) -> None:
+        self.events.append(event)
+
+
+@pytest.fixture
+def recorder() -> RecordingBackend:
+    """Provide a fresh registry backed by a RecordingBackend per test."""
+    from synapto.telemetry.metrics import MetricsRegistry, set_registry
+
+    backend = RecordingBackend()
+    set_registry(MetricsRegistry(backend=backend))
+    yield backend
+    set_registry(None)  # restore default singleton on teardown
+
+
+def test_counter_emits_event(recorder: RecordingBackend) -> None:
+    from synapto.telemetry.metrics import get_registry
+
+    get_registry().counter("synapto.tool.recall.calls", 3, tenant="acme")
+
+    assert len(recorder.events) == 1
+    evt = recorder.events[0]
+    assert evt.name == "synapto.tool.recall.calls"
+    assert evt.type == "counter"
+    assert evt.value == 3.0
+    assert evt.tags == {"tenant": "acme"}
+
+
+def test_gauge_emits_event(recorder: RecordingBackend) -> None:
+    from synapto.telemetry.metrics import get_registry
+
+    get_registry().gauge("synapto.pool.in_use", 5.0)
+
+    assert len(recorder.events) == 1
+    evt = recorder.events[0]
+    assert evt.name == "synapto.pool.in_use"
+    assert evt.type == "gauge"
+    assert evt.value == 5.0
+    assert evt.tags == {}
+
+
+def test_histogram_emits_event(recorder: RecordingBackend) -> None:
+    from synapto.telemetry.metrics import get_registry
+
+    get_registry().histogram("synapto.recall.vector_ms", 23.4, tenant="acme", depth="core")
+
+    assert len(recorder.events) == 1
+    evt = recorder.events[0]
+    assert evt.name == "synapto.recall.vector_ms"
+    assert evt.type == "histogram"
+    assert evt.value == pytest.approx(23.4)
+    assert evt.tags == {"tenant": "acme", "depth": "core"}
+
+
+@pytest.mark.asyncio
+async def test_measure_success_emits_histogram_with_outcome_ok(
+    recorder: RecordingBackend,
+) -> None:
+    from synapto.telemetry.metrics import measure
+
+    async with measure("synapto.op.total", tenant="acme"):
+        pass
+
+    assert len(recorder.events) == 1
+    evt = recorder.events[0]
+    assert evt.name == "synapto.op.total"
+    assert evt.type == "histogram"
+    assert evt.value >= 0.0
+    assert evt.tags == {"tenant": "acme", "outcome": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_measure_exception_emits_outcome_error_and_reraises(
+    recorder: RecordingBackend,
+) -> None:
+    from synapto.telemetry.metrics import measure
+
+    with pytest.raises(ValueError, match="boom"):
+        async with measure("synapto.op.total", tenant="acme"):
+            raise ValueError("boom")
+
+    assert len(recorder.events) == 1
+    evt = recorder.events[0]
+    assert evt.name == "synapto.op.total"
+    assert evt.type == "histogram"
+    assert evt.value >= 0.0
+    assert evt.tags == {"tenant": "acme", "outcome": "error"}
+
+
+def test_set_registry_swaps_singleton() -> None:
+    """get_registry returns a singleton; set_registry replaces it; set_registry(None) resets."""
+    from synapto.telemetry.metrics import (
+        LogMetricsBackend,
+        MetricsRegistry,
+        get_registry,
+        set_registry,
+    )
+
+    set_registry(None)  # ensure clean default state
+
+    # default factory yields a stable singleton
+    first = get_registry()
+    second = get_registry()
+    assert first is second
+    assert isinstance(first._backend, LogMetricsBackend)  # type: ignore[attr-defined]
+
+    # swap to a custom registry
+    custom = MetricsRegistry(backend=RecordingBackend())
+    set_registry(custom)
+    assert get_registry() is custom
+
+    # reset goes back to a fresh default (not the same instance as before)
+    set_registry(None)
+    third = get_registry()
+    assert third is not custom
+    assert isinstance(third._backend, LogMetricsBackend)  # type: ignore[attr-defined]

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -2,12 +2,17 @@
 
 Validates the contract that:
 - counter/gauge/histogram emit MetricEvent objects to the configured backend
-- measure() async ctx mgr times the block, tags outcome=ok on success and
-  outcome=error on exception (and reraises), and emits a histogram event
+- MetricEvent.tags is read-only after construction (frozen=True is not enough)
+- measure() async ctx mgr times the block and tags outcome=ok | error | cancelled
+- measure() rejects callers trying to override the reserved ``outcome`` tag
+- KeyboardInterrupt / SystemExit propagate without emitting a metric
 - get_registry returns a singleton; set_registry swaps it (for tests/config)
 """
 
 from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
 
 import pytest
 
@@ -23,7 +28,7 @@ class RecordingBackend:
 
 
 @pytest.fixture
-def recorder() -> RecordingBackend:
+def recorder() -> Iterator[RecordingBackend]:
     """Provide a fresh registry backed by a RecordingBackend per test."""
     from synapto.telemetry.metrics import MetricsRegistry, set_registry
 
@@ -105,6 +110,61 @@ async def test_measure_exception_emits_outcome_error_and_reraises(
     assert evt.type == "histogram"
     assert evt.value >= 0.0
     assert evt.tags == {"tenant": "acme", "outcome": "error"}
+
+
+@pytest.mark.asyncio
+async def test_measure_cancelled_emits_outcome_cancelled_and_reraises(
+    recorder: RecordingBackend,
+) -> None:
+    """asyncio.CancelledError is normal lifecycle in MCP/async — must NOT be tagged as error."""
+    from synapto.telemetry.metrics import measure
+
+    with pytest.raises(asyncio.CancelledError):
+        async with measure("synapto.op.total", tenant="acme"):
+            raise asyncio.CancelledError()
+
+    assert len(recorder.events) == 1
+    evt = recorder.events[0]
+    assert evt.tags == {"tenant": "acme", "outcome": "cancelled"}
+
+
+@pytest.mark.asyncio
+async def test_measure_keyboard_interrupt_propagates_without_emitting(
+    recorder: RecordingBackend,
+) -> None:
+    """Interpreter-level shutdown signals must not trigger metric emission."""
+    from synapto.telemetry.metrics import measure
+
+    with pytest.raises(KeyboardInterrupt):
+        async with measure("synapto.op.total", tenant="acme"):
+            raise KeyboardInterrupt()
+
+    assert recorder.events == []
+
+
+@pytest.mark.asyncio
+async def test_measure_rejects_reserved_outcome_tag(recorder: RecordingBackend) -> None:
+    """Caller overriding ``outcome=`` would TypeError inside finally — refuse loudly up-front."""
+    from synapto.telemetry.metrics import measure
+
+    with pytest.raises(ValueError, match="reserved tag"):
+        async with measure("synapto.op.total", outcome="custom"):
+            pass  # pragma: no cover — never executes
+
+    assert recorder.events == []
+
+
+def test_metric_event_tags_are_read_only_after_construction() -> None:
+    """frozen=True alone doesn't protect dict tags; MappingProxyType must back them."""
+    from synapto.telemetry.metrics import MetricEvent
+
+    evt = MetricEvent(name="x", type="counter", value=1.0, tags={"tenant": "acme"})
+
+    with pytest.raises(TypeError):
+        evt.tags["tenant"] = "evil"  # type: ignore[index]
+
+    with pytest.raises(TypeError):
+        evt.tags["new"] = "key"  # type: ignore[index]
 
 
 def test_set_registry_swaps_singleton() -> None:


### PR DESCRIPTION
## Summary

Second task (T2) of issue #9. Adds the metrics primitives — registry, pluggable backend, and async ``measure()`` timer — that every later telemetry task (T3 decorator, T4 Postgres backend, T5/T6 sub-stage instrumentation, T7 config, T8 CLI) will build on.

This PR ships **scaffolding only**. Zero call sites are instrumented yet — that's T3.

## What ships

| Symbol | Role |
|---|---|
| ``MetricEvent`` | frozen dataclass: ``name``, ``type``, ``value``, ``tags`` |
| ``MetricsBackend`` (Protocol) | Strategy contract — ``emit(event)`` |
| ``LogMetricsBackend`` | Adapter — forwards events to ``structlog.get_logger("synapto.metrics")`` |
| ``MetricsRegistry`` | Facade — ``counter`` / ``gauge`` / ``histogram`` |
| ``get_registry()`` / ``set_registry()`` | Process-wide singleton + test/config swap |
| ``measure(name, **tags)`` | Async context manager, auto-tags ``outcome=ok|error``, emits histogram with elapsed ms, re-raises on exception |

## Wire-up with T1

``LogMetricsBackend`` reuses the structlog pipeline configured in T1. Each metric becomes one JSON line in stderr:

```json
{"event":"metric","metric_name":"synapto.recall.vector_ms","metric_type":"histogram","value":23.4,"tenant":"acme","depth":"core","logger":"synapto.metrics","level":"info","timestamp":"..."}
```

## Why this shape

- **Strategy / Adapter / Facade** keep the public surface tiny while letting later PRs swap in the Postgres backend (T4) or OpenTelemetry exporter (v0.4.0) without touching call sites.
- ``measure()`` re-raises on exception so failures stay visible to the caller; the histogram still emits with ``outcome=error`` so error-rate dashboards remain accurate.
- ``set_registry(None)`` resets to the default factory — tests need this to avoid global state bleeding across the test session.

## Tests

``tests/unit/test_metrics.py`` adds 6 tests covering counter / gauge / histogram emission, ``measure`` success and exception paths, and singleton swap/reset.

Full suite: 133 passed (6 new + 127 existing).

## Test plan

- [x] ``uv run pytest tests/ -v`` → 133 passed
- [x] ``uv run ruff check src/ tests/`` → clean
- [x] Smoke script — 5 metric events, all valid JSON, types and tags correct:

```
counter    synapto.tool.recall.calls   value=1.000   tags={'tenant':'acme'}
gauge      synapto.pool.in_use         value=5.000   tags={}
histogram  synapto.recall.vector_ms    value=23.400  tags={'tenant':'acme','depth':'core'}
histogram  synapto.op.total            value=11.127  tags={'outcome':'ok','tenant':'acme'}
histogram  synapto.op.total            value=0.004   tags={'outcome':'error','tenant':'acme'}
```

## Out of scope

| Task | What it adds |
|---|---|
| T3 | ``@instrumented_tool`` decorator applied to the 10 MCP tools |
| T4 | Migration ``006_metrics_events.sql`` + Postgres backend |
| T5 | Sub-stage instrumentation in ``hybrid_search`` (vector / keyword / HRR / RRF) |
| T6 | Sub-stage instrumentation in HRR retrieval / decay / graph / pool |
| T7 | ``[telemetry]`` config block in ``~/.synapto/config.toml`` |
| T8 | ``synapto metrics`` CLI subcommand |