### PR TITLE
feat(telemetry): instrument 10 MCP tools (T3 of #9)

### DIFF
--- a/src/synapto/server.py
+++ b/src/synapto/server.py
@@ -27,6 +27,7 @@ from synapto.repositories.memories import MemoryRepository
 from synapto.repositories.relations import RelationRepository
 from synapto.search.graph import traverse
 from synapto.search.hybrid import hybrid_search
+from synapto.telemetry import instrumented_tool
 
 logger = logging.getLogger("synapto.server")
 
@@ -109,6 +110,7 @@ mcp = FastMCP("synapto", instructions=SERVER_INSTRUCTIONS, lifespan=_lifespan)
 
 
 @mcp.tool(meta=ALWAYS_LOAD_META)
+@instrumented_tool
 async def remember(
     content: str,
     memory_type: str = "general",
@@ -169,6 +171,7 @@ async def remember(
 
 
 @mcp.tool(meta=ALWAYS_LOAD_META)
+@instrumented_tool
 async def recall(
     query: str,
     tenant: str | None = None,
@@ -209,6 +212,7 @@ async def recall(
 
 
 @mcp.tool
+@instrumented_tool
 async def relate(
     from_entity: str,
     to_entity: str,
@@ -237,6 +241,7 @@ async def relate(
 
 
 @mcp.tool
+@instrumented_tool
 async def forget(memory_id: str) -> str:
     """Soft-delete a memory by ID.
 
@@ -254,6 +259,7 @@ async def forget(memory_id: str) -> str:
 
 
 @mcp.tool
+@instrumented_tool
 async def graph_query(
     entity: str,
     hops: int = 2,
@@ -287,6 +293,7 @@ async def graph_query(
 
 
 @mcp.tool
+@instrumented_tool
 async def list_entities_tool(
     tenant: str | None = None,
     entity_type: str | None = None,
@@ -313,6 +320,7 @@ async def list_entities_tool(
 
 
 @mcp.tool
+@instrumented_tool
 async def memory_stats(tenant: str | None = None) -> str:
     """Show memory statistics — counts by type, depth layer, and decay distribution.
 
@@ -350,6 +358,7 @@ async def memory_stats(tenant: str | None = None) -> str:
 
 
 @mcp.tool
+@instrumented_tool
 async def maintain() -> str:
     """Run maintenance tasks — update decay scores, cleanup ephemeral memories."""
     pg = _get_pg()
@@ -359,6 +368,7 @@ async def maintain() -> str:
 
 
 @mcp.tool
+@instrumented_tool
 async def trust_feedback(memory_id: str, helpful: bool) -> str:
     """Adjust a memory's trust score based on feedback.
 
@@ -382,6 +392,7 @@ async def trust_feedback(memory_id: str, helpful: bool) -> str:
 
 
 @mcp.tool
+@instrumented_tool
 async def find_contradictions(tenant: str | None = None, threshold: float = 0.3) -> str:
     """Detect potentially contradictory memories.
 

--- a/src/synapto/telemetry/__init__.py
+++ b/src/synapto/telemetry/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from synapto.telemetry.decorators import instrumented_tool
 from synapto.telemetry.logging import configure_logging
 from synapto.telemetry.metrics import (
     LogMetricsBackend,
@@ -18,6 +19,7 @@ __all__ = [
     "get_registry",
     "set_registry",
     "measure",
+    "instrumented_tool",
     "MetricsRegistry",
     "MetricEvent",
     "MetricsBackend",

--- a/src/synapto/telemetry/decorators.py
+++ b/src/synapto/telemetry/decorators.py
@@ -1,0 +1,73 @@
+"""Decorators that wire instrumentation into Synapto call sites.
+
+Today this module exposes a single decorator, ``instrumented_tool``, designed
+to wrap MCP tool entry points exposed via ``@mcp.tool``. Each wrapped call
+emits two metrics through the configured ``MetricsRegistry``:
+
+    synapto.tool.<name>.latency  (histogram, via ``measure()``, ms)
+    synapto.tool.<name>.calls    (counter, value=1)
+
+Both events carry a consistent ``outcome`` tag derived from how the wrapped
+coroutine resolved:
+
+    ok         -- returned normally
+    error      -- raised a regular ``Exception``
+    cancelled  -- raised ``asyncio.CancelledError`` (normal MCP lifecycle)
+
+Interpreter-level signals (``KeyboardInterrupt``, ``SystemExit``,
+``GeneratorExit``) propagate without emitting any metric, mirroring
+``measure()``'s behavior — emitting during teardown risks writing to a logger
+that is already being closed.
+
+Decorator order with ``@mcp.tool`` matters: ``@mcp.tool`` MUST stay outer so
+FastMCP sees the instrumented wrapper at registration time and the ``meta=``
+argument continues to apply to the registered tool object:
+
+    @mcp.tool(meta=ALWAYS_LOAD_META)   # OUTER  -- registers + sets meta
+    @instrumented_tool                 # INNER  -- adds metrics
+    async def remember(...): ...
+
+``functools.wraps`` preserves ``__name__`` and ``__doc__`` so FastMCP's
+function-name and docstring inference still produce the expected tool name
+and description.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+from synapto.telemetry.metrics import get_registry, measure
+
+T = TypeVar("T")
+
+
+def instrumented_tool(func: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]:
+    """Wrap an async MCP tool so each invocation emits a latency histogram and a calls counter."""
+    name = func.__name__
+    metric_latency = f"synapto.tool.{name}.latency"
+    metric_calls = f"synapto.tool.{name}.calls"
+
+    @functools.wraps(func)
+    async def wrapper(*args, **kwargs) -> T:
+        outcome: str | None = None
+        try:
+            async with measure(metric_latency):
+                result = await func(*args, **kwargs)
+            outcome = "ok"
+            return result
+        except asyncio.CancelledError:
+            outcome = "cancelled"
+            raise
+        except Exception:
+            outcome = "error"
+            raise
+        finally:
+            # Skip the counter on KeyboardInterrupt / SystemExit / GeneratorExit
+            # to match measure()'s teardown semantics.
+            if outcome is not None:
+                get_registry().counter(metric_calls, 1, outcome=outcome)
+
+    return wrapper

--- a/tests/unit/test_telemetry_decorators.py
+++ b/tests/unit/test_telemetry_decorators.py
@@ -1,0 +1,142 @@
+"""Tests for synapto.telemetry.decorators.instrumented_tool.
+
+The decorator wraps an async MCP tool and emits two metrics per invocation:
+- ``synapto.tool.<name>.latency``  (histogram, via ``measure()``, auto outcome tag)
+- ``synapto.tool.<name>.calls``    (counter, value=1, manual outcome tag)
+
+Outcome propagates consistently across both metrics:
+- ``ok``        -- function returned without raising
+- ``error``     -- function raised a regular ``Exception``
+- ``cancelled`` -- function raised ``asyncio.CancelledError``
+- (no metric) -- ``KeyboardInterrupt`` / ``SystemExit`` / ``GeneratorExit`` propagate silently
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+
+import pytest
+
+
+class RecordingBackend:
+    """Stub backend that captures emitted events for assertion."""
+
+    def __init__(self) -> None:
+        self.events: list = []
+
+    def emit(self, event) -> None:
+        self.events.append(event)
+
+
+@pytest.fixture
+def recorder() -> Iterator[RecordingBackend]:
+    from synapto.telemetry.metrics import MetricsRegistry, set_registry
+
+    backend = RecordingBackend()
+    set_registry(MetricsRegistry(backend=backend))
+    yield backend
+    set_registry(None)
+
+
+def _by_name(events: list, name: str) -> list:
+    return [e for e in events if e.name == name]
+
+
+@pytest.mark.asyncio
+async def test_happy_path_emits_counter_and_latency(recorder: RecordingBackend) -> None:
+    from synapto.telemetry.decorators import instrumented_tool
+
+    @instrumented_tool
+    async def my_tool(value: int) -> int:
+        return value * 2
+
+    result = await my_tool(21)
+    assert result == 42
+
+    latency = _by_name(recorder.events, "synapto.tool.my_tool.latency")
+    calls = _by_name(recorder.events, "synapto.tool.my_tool.calls")
+
+    assert len(latency) == 1
+    assert latency[0].type == "histogram"
+    assert latency[0].value >= 0.0
+    assert latency[0].tags == {"outcome": "ok"}
+
+    assert len(calls) == 1
+    assert calls[0].type == "counter"
+    assert calls[0].value == 1.0
+    assert calls[0].tags == {"outcome": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_exception_path_emits_outcome_error_and_reraises(
+    recorder: RecordingBackend,
+) -> None:
+    from synapto.telemetry.decorators import instrumented_tool
+
+    @instrumented_tool
+    async def my_tool() -> None:
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        await my_tool()
+
+    latency = _by_name(recorder.events, "synapto.tool.my_tool.latency")
+    calls = _by_name(recorder.events, "synapto.tool.my_tool.calls")
+
+    assert len(latency) == 1
+    assert latency[0].tags == {"outcome": "error"}
+    assert len(calls) == 1
+    assert calls[0].tags == {"outcome": "error"}
+
+
+@pytest.mark.asyncio
+async def test_cancelled_path_emits_outcome_cancelled_and_reraises(
+    recorder: RecordingBackend,
+) -> None:
+    from synapto.telemetry.decorators import instrumented_tool
+
+    @instrumented_tool
+    async def my_tool() -> None:
+        raise asyncio.CancelledError()
+
+    with pytest.raises(asyncio.CancelledError):
+        await my_tool()
+
+    latency = _by_name(recorder.events, "synapto.tool.my_tool.latency")
+    calls = _by_name(recorder.events, "synapto.tool.my_tool.calls")
+
+    assert len(latency) == 1
+    assert latency[0].tags == {"outcome": "cancelled"}
+    assert len(calls) == 1
+    assert calls[0].tags == {"outcome": "cancelled"}
+
+
+@pytest.mark.asyncio
+async def test_metric_name_derived_from_func_name(recorder: RecordingBackend) -> None:
+    from synapto.telemetry.decorators import instrumented_tool
+
+    @instrumented_tool
+    async def find_contradictions() -> str:
+        return "ok"
+
+    await find_contradictions()
+
+    names = {e.name for e in recorder.events}
+    assert names == {
+        "synapto.tool.find_contradictions.latency",
+        "synapto.tool.find_contradictions.calls",
+    }
+
+
+def test_decorator_preserves_function_metadata() -> None:
+    """functools.wraps must keep __name__ and __doc__ so FastMCP registers correctly."""
+    from synapto.telemetry.decorators import instrumented_tool
+
+    @instrumented_tool
+    async def my_tool() -> str:
+        """Original docstring used by MCP description discovery."""
+        return "ok"
+
+    assert my_tool.__name__ == "my_tool"
+    assert my_tool.__doc__ == "Original docstring used by MCP description discovery."


### PR DESCRIPTION
## Summary

Third task (T3) of issue #9. First call site of the metrics primitives shipped in T2 (PR #31). Adds ``instrumented_tool`` decorator and applies it to all 10 MCP tools.

Every tool invocation now emits two metric events through the configured ``MetricsRegistry``:

```
synapto.tool.<name>.latency  (histogram, ms, via measure())
synapto.tool.<name>.calls    (counter, value=1)
```

Both events carry a consistent ``outcome`` tag: ``ok`` / ``error`` / ``cancelled``. Interpreter-level signals (``KeyboardInterrupt``, ``SystemExit``, ``GeneratorExit``) propagate without emitting any metric, mirroring ``measure()``'s teardown semantics.

## Decorator order is load-bearing

```python
@mcp.tool(meta=ALWAYS_LOAD_META)   # OUTER — registers + sets meta
@instrumented_tool                 # INNER — adds metrics
async def remember(...): ...
```

- ``@mcp.tool`` MUST stay outer so FastMCP sees the instrumented wrapper at registration time and the ``meta=`` argument continues to apply.
- ``functools.wraps`` preserves ``__name__`` and ``__doc__`` so FastMCP's function-name / docstring inference still produces the expected tool name and description.

## Tools instrumented (10/10)

remember, recall, relate, forget, graph_query, list_entities_tool, memory_stats, maintain, trust_feedback, find_contradictions.

## Tests

``tests/unit/test_telemetry_decorators.py`` adds 5 cases:

1. Happy path emits both metrics with ``outcome=ok``
2. Exception path emits ``outcome=error`` and re-raises
3. ``asyncio.CancelledError`` emits ``outcome=cancelled`` (not ``error``)
4. Metric names derived from ``func.__name__``
5. ``functools.wraps`` preserves ``__name__`` and ``__doc__``

Suite total: **142 passed** (5 new + 137 existing).

The existing ``tests/unit/test_tool_metadata.py`` (11 cases) is the regression gate for FastMCP ``meta`` preservation. It's unchanged and still green — confirming the decorator order keeps ``alwaysLoad`` metadata intact on ``remember`` and ``recall``.

## Test plan

- [x] ``uv run pytest tests/ -v`` → 142 passed
- [x] ``uv run pytest tests/unit/test_tool_metadata.py -v`` → 11 passed (regression gate)
- [x] ``uv run ruff check src/ tests/`` → clean
- [x] End-to-end smoke against a live Postgres — calling ``memory_stats`` emits the expected two events:

```
histogram  synapto.tool.memory_stats.latency  value=47.723  tags={'outcome': 'ok'}
counter    synapto.tool.memory_stats.calls    value=1.000   tags={'outcome': 'ok'}
```

## Out of scope (next tasks under #9)

| Task | Adds |
|---|---|
| T4 | ``migrations/006_metrics_events.sql`` + ``PostgresMetricsBackend`` |
| T5 | Sub-stage instrumentation in ``hybrid_search`` (vector / keyword / HRR / RRF) |
| T6 | Sub-stage instrumentation in HRR retrieval / decay / graph / pool |
| T7 | ``[telemetry]`` config block in ``~/.synapto/config.toml`` |
| T8 | ``synapto metrics`` CLI subcommand |