### PR TITLE
feat(mcp): add full memory retrieval tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Restart your agent. Synapto tools appear automatically, and any future release w
 |------|-------------|
 | `remember` | Store a memory (entities and search vectors are created automatically) |
 | `recall` | Search memories by meaning |
+| `get_memory` | Fetch the complete content and metadata for one recalled memory |
+| `get_memories` | Fetch complete content for multiple recalled memories |
 | `relate` | Link two entities ("Hermes" --[produces]--> "agent.messages") |
 | `forget` | Soft-delete a memory |
 | `trust_feedback` | Mark a memory as helpful or unhelpful |

--- a/docs/repository-pattern.md
+++ b/docs/repository-pattern.md
@@ -84,6 +84,8 @@ rows = await repo.soft_delete(memory_id)
 | Method | Description |
 |--------|-------------|
 | `create()` | Insert a new memory with embedding |
+| `get_by_id()` | Fetch a complete active memory by ID |
+| `get_by_ids()` | Fetch multiple active memories by ID |
 | `update_hrr()` | Store HRR vector for a memory |
 | `soft_delete()` | Set deleted_at timestamp |
 | `update_trust()` | Adjust trust score (asymmetric +0.05/-0.10) |

--- a/docs/repository-pattern.md
+++ b/docs/repository-pattern.md
@@ -110,6 +110,7 @@ rows = await repo.soft_delete(memory_id)
 | `delete()` | Delete an entity by name |
 | `link_memory()` | Create memory-entity association |
 | `get_memory_entities()` | Get all entities linked to a memory |
+| `get_entities_for_memories()` | Batch get entities linked to multiple memories |
 | `count()` | Count entities, optionally filtered by tenant |
 
 ### RelationRepository
@@ -119,6 +120,7 @@ rows = await repo.soft_delete(memory_id)
 | `upsert()` | Create or update a relation by entity IDs |
 | `upsert_by_name()` | Create relation using entity names (joins internally) |
 | `get_relations()` | Get relations for an entity (outgoing, incoming, or both) |
+| `get_relations_for_entities()` | Batch get relations touching any of several entities |
 | `delete()` | Delete a relation by ID |
 | `count()` | Count total relations |
 

--- a/src/synapto/repositories/entities.py
+++ b/src/synapto/repositories/entities.py
@@ -49,6 +49,14 @@ _GET_MEMORY_ENTITIES = """
     WHERE me.memory_id = %s;
 """
 
+_GET_ENTITIES_FOR_MEMORIES = """
+    SELECT me.memory_id, e.id, e.name, e.entity_type
+    FROM memory_entities me
+    JOIN entities e ON e.id = me.entity_id
+    WHERE me.memory_id = ANY(%s::uuid[])
+    ORDER BY me.memory_id, e.name;
+"""
+
 _COUNT = "SELECT count(*) as cnt FROM entities"
 
 _GET_ENTITY_IDS_FOR_MEMORY = """
@@ -76,14 +84,17 @@ class EntityRepository:
         embedding: list[float] | None = None,
         embedding_dim: int | None = None,
     ) -> UUID:
-        row = await self._db.execute_one(_UPSERT, {
-            "name": name,
-            "type": entity_type,
-            "tenant": tenant,
-            "meta": Jsonb(metadata or {}),
-            "emb": embedding,
-            "dim": embedding_dim,
-        })
+        row = await self._db.execute_one(
+            _UPSERT,
+            {
+                "name": name,
+                "type": entity_type,
+                "tenant": tenant,
+                "meta": Jsonb(metadata or {}),
+                "emb": embedding,
+                "dim": embedding_dim,
+            },
+        )
         return row["id"]
 
     async def get_by_name(self, name: str, tenant: str = "default") -> dict[str, Any] | None:
@@ -109,6 +120,16 @@ class EntityRepository:
 
     async def get_memory_entities(self, memory_id: UUID) -> list[dict[str, Any]]:
         return await self._db.execute(_GET_MEMORY_ENTITIES, (memory_id,))
+
+    async def get_entities_for_memories(self, memory_ids: list[UUID]) -> dict[UUID, list[dict[str, Any]]]:
+        if not memory_ids:
+            return {}
+
+        rows = await self._db.execute(_GET_ENTITIES_FOR_MEMORIES, (memory_ids,))
+        grouped: dict[UUID, list[dict[str, Any]]] = {}
+        for row in rows:
+            grouped.setdefault(row["memory_id"], []).append(row)
+        return grouped
 
     async def get_entity_ids_for_memory(self, memory_id: UUID) -> list[UUID]:
         rows = await self._db.execute(_GET_ENTITY_IDS_FOR_MEMORY, (memory_id,))

--- a/src/synapto/repositories/memories.py
+++ b/src/synapto/repositories/memories.py
@@ -23,6 +23,42 @@ _INSERT = """
     RETURNING id;
 """
 
+_GET_BY_ID = """
+    SELECT
+        id,
+        content,
+        summary,
+        type,
+        tenant,
+        depth_layer,
+        metadata,
+        decay_score,
+        trust_score,
+        access_count,
+        created_at,
+        accessed_at
+    FROM memories
+    WHERE id = %s AND deleted_at IS NULL;
+"""
+
+_GET_BY_IDS = """
+    SELECT
+        id,
+        content,
+        summary,
+        type,
+        tenant,
+        depth_layer,
+        metadata,
+        decay_score,
+        trust_score,
+        access_count,
+        created_at,
+        accessed_at
+    FROM memories
+    WHERE id = ANY(%s::uuid[]) AND deleted_at IS NULL;
+"""
+
 _UPDATE_HRR = "UPDATE memories SET hrr_vector = %s, hrr_dim = %s WHERE id = %s;"
 
 _SOFT_DELETE = """
@@ -126,20 +162,31 @@ class MemoryRepository:
         summary: str | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> UUID:
-        row = await self._db.execute_one(_INSERT, {
-            "content": content,
-            "summary": summary,
-            "emb": embedding,
-            "dim": embedding_dim,
-            "type": memory_type,
-            "tenant": tenant,
-            "depth": depth_layer,
-            "meta": Jsonb(metadata or {}),
-        })
+        row = await self._db.execute_one(
+            _INSERT,
+            {
+                "content": content,
+                "summary": summary,
+                "emb": embedding,
+                "dim": embedding_dim,
+                "type": memory_type,
+                "tenant": tenant,
+                "depth": depth_layer,
+                "meta": Jsonb(metadata or {}),
+            },
+        )
         return row["id"]
 
     async def update_hrr(self, memory_id: UUID, hrr_vector: bytes, hrr_dim: int) -> None:
         await self._db.execute(_UPDATE_HRR, (hrr_vector, hrr_dim, memory_id))
+
+    async def get_by_id(self, memory_id: str | UUID) -> dict[str, Any] | None:
+        return await self._db.execute_one(_GET_BY_ID, (memory_id,))
+
+    async def get_by_ids(self, memory_ids: list[str | UUID]) -> list[dict[str, Any]]:
+        if not memory_ids:
+            return []
+        return await self._db.execute(_GET_BY_IDS, (memory_ids,))
 
     async def soft_delete(self, memory_id: str) -> list[dict]:
         return await self._db.execute(_SOFT_DELETE, (memory_id,))
@@ -166,8 +213,9 @@ class MemoryRepository:
 
     # -- hrr vectors --
 
-    async def select_hrr_vectors(self, tenant: str, type_filter: str | None = None,
-                                 depth_filter: str | None = None) -> list[dict]:
+    async def select_hrr_vectors(
+        self, tenant: str, type_filter: str | None = None, depth_filter: str | None = None
+    ) -> list[dict]:
         where = ["deleted_at IS NULL", "tenant = %s", "hrr_vector IS NOT NULL"]
         params: list = [tenant]
         if type_filter:
@@ -181,8 +229,7 @@ class MemoryRepository:
 
     # -- hrr retrieval --
 
-    async def select_with_hrr(self, tenant: str, depth_layer: str | None = None,
-                              limit: int = 100) -> list[dict]:
+    async def select_with_hrr(self, tenant: str, depth_layer: str | None = None, limit: int = 100) -> list[dict]:
         where = ["deleted_at IS NULL", "tenant = %s", "hrr_vector IS NOT NULL"]
         params: list = [tenant]
         if depth_layer:

--- a/src/synapto/repositories/relations.py
+++ b/src/synapto/repositories/relations.py
@@ -63,6 +63,18 @@ _GET_BOTH = """
     WHERE (ef.name = %s OR et.name = %s) AND ef.tenant = %s;
 """
 
+_GET_FOR_ENTITIES = """
+    SELECT r.id, r.relation_type, r.weight,
+           ef.name AS from_entity, et.name AS to_entity
+    FROM relations r
+    JOIN entities ef ON ef.id = r.from_entity_id
+    JOIN entities et ON et.id = r.to_entity_id
+    WHERE ef.tenant = %s
+      AND et.tenant = %s
+      AND (ef.name = ANY(%s) OR et.name = ANY(%s))
+    ORDER BY r.relation_type, ef.name, et.name;
+"""
+
 _DELETE = "DELETE FROM relations WHERE id = %s RETURNING id;"
 
 _COUNT = "SELECT count(*) as cnt FROM relations;"
@@ -87,13 +99,16 @@ class RelationRepository:
         weight: float = 1.0,
         metadata: dict[str, Any] | None = None,
     ) -> UUID:
-        row = await self._db.execute_one(_UPSERT, {
-            "from_id": from_entity_id,
-            "to_id": to_entity_id,
-            "type": relation_type,
-            "weight": weight,
-            "meta": Jsonb(metadata or {}),
-        })
+        row = await self._db.execute_one(
+            _UPSERT,
+            {
+                "from_id": from_entity_id,
+                "to_id": to_entity_id,
+                "type": relation_type,
+                "weight": weight,
+                "meta": Jsonb(metadata or {}),
+            },
+        )
         return row["id"]
 
     async def upsert_by_name(
@@ -104,13 +119,16 @@ class RelationRepository:
         tenant: str = "default",
         weight: float = 1.0,
     ) -> UUID | None:
-        row = await self._db.execute_one(_UPSERT_BY_NAME, {
-            "from": from_name,
-            "to": to_name,
-            "type": relation_type,
-            "tenant": tenant,
-            "weight": weight,
-        })
+        row = await self._db.execute_one(
+            _UPSERT_BY_NAME,
+            {
+                "from": from_name,
+                "to": to_name,
+                "type": relation_type,
+                "tenant": tenant,
+                "weight": weight,
+            },
+        )
         return row["id"] if row else None
 
     async def get_relations(
@@ -124,6 +142,22 @@ class RelationRepository:
         elif direction == "incoming":
             return await self._db.execute(_GET_INCOMING, (entity_name, tenant))
         return await self._db.execute(_GET_BOTH, (entity_name, entity_name, tenant))
+
+    async def get_relations_for_entities(
+        self, entity_names: list[str], tenant: str = "default"
+    ) -> list[dict[str, Any]]:
+        if not entity_names:
+            return []
+
+        rows = await self._db.execute(_GET_FOR_ENTITIES, (tenant, tenant, entity_names, entity_names))
+        seen: set[UUID] = set()
+        deduped = []
+        for row in rows:
+            if row["id"] in seen:
+                continue
+            seen.add(row["id"])
+            deduped.append(row)
+        return deduped
 
     async def delete(self, relation_id: UUID) -> bool:
         rows = await self._db.execute(_DELETE, (relation_id,))

--- a/src/synapto/search/hybrid.py
+++ b/src/synapto/search/hybrid.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 from uuid import UUID
 
@@ -101,6 +102,9 @@ class SearchResult:
     trust_score: float
     rrf_score: float
     metadata: dict[str, Any]
+    access_count: int
+    created_at: datetime
+    accessed_at: datetime
 
 
 def _compute_hrr_boost(query: str, hrr_vector: bytes | None, hrr_weight: float = 0.15) -> float:
@@ -178,6 +182,9 @@ async def hybrid_search(
             trust_score=row.get("trust_score", 0.5),
             rrf_score=final_score,
             metadata=row["metadata"] or {},
+            access_count=row["access_count"],
+            created_at=row["created_at"],
+            accessed_at=row["accessed_at"],
         )
         for row, final_score in scored_rows
     ]
@@ -235,6 +242,9 @@ async def vector_search(
             trust_score=row.get("trust_score", 0.5),
             rrf_score=row.get("similarity", 0.0),
             metadata=row["metadata"] or {},
+            access_count=row["access_count"],
+            created_at=row["created_at"],
+            accessed_at=row["accessed_at"],
         )
         for row in rows
     ]

--- a/src/synapto/server.py
+++ b/src/synapto/server.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from contextlib import asynccontextmanager
+from datetime import datetime
 from typing import Any
 from uuid import UUID
 
@@ -95,6 +97,9 @@ SERVER_INSTRUCTIONS = load_prompt("server_instructions")
 # skips the deferred-tool `ToolSearch` handshake and loads the schema eagerly.
 # Reserved for the two tools the LLM is expected to call in most conversations.
 ALWAYS_LOAD_META = {"alwaysLoad": True}
+MAX_RECALL_PREVIEW_CHARS = 1000
+DEFAULT_RECALL_PREVIEW_CHARS = 200
+MAX_BULK_MEMORY_IDS = 20
 
 
 def _wrap_system_reminder(body: str) -> str:
@@ -105,6 +110,68 @@ def _wrap_system_reminder(body: str) -> str:
     clients will render the tags verbatim — harmless but not as seamless.
     """
     return f"<system-reminder>\n{body.strip()}\n</system-reminder>"
+
+
+def _format_timestamp(value: datetime | None) -> str:
+    if value is None:
+        return ""
+    return value.isoformat()
+
+
+def _format_json(value: dict[str, Any] | None) -> str:
+    return json.dumps(value or {}, ensure_ascii=False, sort_keys=True)
+
+
+def _format_memory(
+    row: dict[str, Any],
+    *,
+    include_entities: bool = False,
+    entities: list[dict[str, Any]] | None = None,
+    include_relations: bool = False,
+    relations: list[dict[str, Any]] | None = None,
+) -> str:
+    lines = [
+        f"id: {row['id']}",
+        f"tenant: {row['tenant']}",
+        f"type: {row['type']}",
+        f"depth_layer: {row['depth_layer']}",
+        f"trust_score: {float(row.get('trust_score', 0.5)):.2f}",
+        f"decay_score: {float(row.get('decay_score', 1.0)):.2f}",
+        f"access_count: {row.get('access_count', 0)}",
+        f"created_at: {_format_timestamp(row.get('created_at'))}",
+        f"accessed_at: {_format_timestamp(row.get('accessed_at'))}",
+    ]
+    if row.get("summary"):
+        lines.append(f"summary: {row['summary']}")
+    lines.append(f"metadata: {_format_json(row.get('metadata'))}")
+
+    if include_entities:
+        entity_names = [e["name"] for e in entities or []]
+        lines.append(f"entities: {', '.join(entity_names) if entity_names else '(none)'}")
+
+    if include_relations:
+        rel_lines = [f"{r['from_entity']} --[{r['relation_type']}]--> {r['to_entity']}" for r in relations or []]
+        lines.append("relations:")
+        if rel_lines:
+            lines.extend(f"  {line}" for line in rel_lines)
+        else:
+            lines.append("  (none)")
+
+    lines.append("content:")
+    lines.append(row["content"])
+    return "\n".join(lines)
+
+
+def _parse_memory_ids(memory_ids: list[str]) -> tuple[list[UUID], list[str]]:
+    valid_ids: list[UUID] = []
+    invalid_ids: list[str] = []
+    for memory_id in memory_ids:
+        try:
+            valid_ids.append(UUID(memory_id))
+        except ValueError:
+            invalid_ids.append(memory_id)
+    return valid_ids, invalid_ids
+
 
 mcp = FastMCP("synapto", instructions=SERVER_INSTRUCTIONS, lifespan=_lifespan)
 
@@ -177,6 +244,7 @@ async def recall(
     tenant: str | None = None,
     depth_layer: str | None = None,
     limit: int = 10,
+    preview_chars: int = DEFAULT_RECALL_PREVIEW_CHARS,
 ) -> str:
     """Search memories using hybrid semantic + keyword search with RRF ranking.
 
@@ -185,10 +253,12 @@ async def recall(
         tenant: filter to a specific project/tenant
         depth_layer: filter to a specific depth layer (core, stable, working, ephemeral)
         limit: max results to return
+        preview_chars: max content characters per result (0-1000)
     """
     pg = _get_pg()
     provider = _get_provider()
     t = tenant or _config.default_tenant
+    preview_chars = max(0, min(preview_chars, MAX_RECALL_PREVIEW_CHARS))
 
     results = await hybrid_search(pg, provider, query, tenant=t, depth_layer=depth_layer, limit=limit)
 
@@ -197,18 +267,121 @@ async def recall(
 
     memories = []
     for r in results:
+        preview = r.content[:preview_chars]
+        if preview_chars and len(r.content) > preview_chars:
+            preview += "..."
         memories.append(
             f"[{r.depth_layer}] ({r.type}) score={r.rrf_score:.4f} "
-            f"decay={r.decay_score:.2f} trust={r.trust_score:.2f}\n"
-            f"  {r.content[:200]}{'...' if len(r.content) > 200 else ''}\n"
+            f"decay={r.decay_score:.2f} trust={r.trust_score:.2f} "
+            f"tenant={r.tenant} created_at={_format_timestamp(r.created_at)}\n"
+            f"  {preview}\n"
             f"  id={r.id}"
         )
-    body = (
-        f"{load_prompt('recall_preamble')}\n"
-        f"Recalled {len(results)} memories:\n\n"
-        + "\n\n".join(memories)
-    )
+    body = f"{load_prompt('recall_preamble')}\nRecalled {len(results)} memories:\n\n" + "\n\n".join(memories)
     return _wrap_system_reminder(body)
+
+
+@mcp.tool
+@instrumented_tool
+async def get_memory(
+    memory_id: str,
+    include_entities: bool = True,
+    include_relations: bool = False,
+) -> str:
+    """Fetch a complete memory by ID after recall identifies a relevant hit.
+
+    Args:
+        memory_id: UUID of the memory to fetch
+        include_entities: include entities linked to the memory
+        include_relations: include relations for linked entities
+    """
+    pg = _get_pg()
+    try:
+        parsed_id = UUID(memory_id)
+    except ValueError:
+        return f"invalid memory id: {memory_id}"
+
+    mem_repo = MemoryRepository(pg)
+    row = await mem_repo.get_by_id(parsed_id)
+    if not row:
+        return f"memory {memory_id} not found or deleted"
+
+    entities = []
+    relations = []
+    if include_entities or include_relations:
+        ent_repo = EntityRepository(pg)
+        entities = await ent_repo.get_memory_entities(parsed_id)
+
+    if include_relations and entities:
+        rel_repo = RelationRepository(pg)
+        seen_relation_ids: set[UUID] = set()
+        for entity in entities:
+            for relation in await rel_repo.get_relations(entity["name"], row["tenant"]):
+                if relation["id"] in seen_relation_ids:
+                    continue
+                seen_relation_ids.add(relation["id"])
+                relations.append(relation)
+
+    return _format_memory(
+        row,
+        include_entities=include_entities,
+        entities=entities,
+        include_relations=include_relations,
+        relations=relations,
+    )
+
+
+@mcp.tool
+@instrumented_tool
+async def get_memories(
+    memory_ids: list[str],
+    include_entities: bool = False,
+) -> str:
+    """Fetch multiple complete memories by ID, preserving the requested order.
+
+    Args:
+        memory_ids: UUIDs of memories to fetch (max 20)
+        include_entities: include entities linked to each memory
+    """
+    if len(memory_ids) > MAX_BULK_MEMORY_IDS:
+        return f"too many memory ids: max {MAX_BULK_MEMORY_IDS}, got {len(memory_ids)}"
+
+    valid_ids, invalid_ids = _parse_memory_ids(memory_ids)
+    rows = []
+    if valid_ids:
+        pg = _get_pg()
+        mem_repo = MemoryRepository(pg)
+        rows = await mem_repo.get_by_ids(valid_ids)
+    by_id = {str(row["id"]): row for row in rows}
+
+    entities_by_id: dict[str, list[dict[str, Any]]] = {}
+    if include_entities and rows:
+        pg = _get_pg()
+        ent_repo = EntityRepository(pg)
+        for row in rows:
+            entities_by_id[str(row["id"])] = await ent_repo.get_memory_entities(row["id"])
+
+    output = []
+    invalid = set(invalid_ids)
+    for memory_id in memory_ids:
+        if memory_id in invalid:
+            output.append(f"memory {memory_id}: invalid id")
+            continue
+
+        row = by_id.get(memory_id)
+        if not row:
+            output.append(f"memory {memory_id}: not found or deleted")
+            continue
+
+        output.append(
+            _format_memory(
+                row,
+                include_entities=include_entities,
+                entities=entities_by_id.get(memory_id),
+            )
+        )
+
+    return "\n\n---\n\n".join(output) if output else "no memory ids provided"
 
 
 @mcp.tool

--- a/src/synapto/server.py
+++ b/src/synapto/server.py
@@ -10,6 +10,7 @@ from typing import Any
 from uuid import UUID
 
 from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
 
 from synapto.config import load_config
 from synapto.db.migrations import ensure_hnsw_index, run_migrations
@@ -100,6 +101,7 @@ ALWAYS_LOAD_META = {"alwaysLoad": True}
 MAX_RECALL_PREVIEW_CHARS = 1000
 DEFAULT_RECALL_PREVIEW_CHARS = 200
 MAX_BULK_MEMORY_IDS = 20
+RECALL_CONTENT_ELIDED = "[content elided - fetch full via get_memory(id)]"
 
 
 def _wrap_system_reminder(body: str) -> str:
@@ -267,9 +269,12 @@ async def recall(
 
     memories = []
     for r in results:
-        preview = r.content[:preview_chars]
-        if preview_chars and len(r.content) > preview_chars:
-            preview += "..."
+        if preview_chars == 0:
+            preview = RECALL_CONTENT_ELIDED
+        else:
+            preview = r.content[:preview_chars]
+            if len(r.content) > preview_chars:
+                preview += "..."
         memories.append(
             f"[{r.depth_layer}] ({r.type}) score={r.rrf_score:.4f} "
             f"decay={r.decay_score:.2f} trust={r.trust_score:.2f} "
@@ -292,8 +297,11 @@ async def get_memory(
 
     Args:
         memory_id: UUID of the memory to fetch
-        include_entities: include entities linked to the memory
-        include_relations: include relations for linked entities
+        include_entities: include entities linked to the memory in the output
+        include_relations: include relations for linked entities in the output.
+            Note: setting this to True implicitly fetches entities (needed to
+            traverse the graph), but they are only displayed when
+            include_entities=True is also set.
     """
     pg = _get_pg()
     try:
@@ -314,13 +322,8 @@ async def get_memory(
 
     if include_relations and entities:
         rel_repo = RelationRepository(pg)
-        seen_relation_ids: set[UUID] = set()
-        for entity in entities:
-            for relation in await rel_repo.get_relations(entity["name"], row["tenant"]):
-                if relation["id"] in seen_relation_ids:
-                    continue
-                seen_relation_ids.add(relation["id"])
-                relations.append(relation)
+        entity_names = [entity["name"] for entity in entities]
+        relations = await rel_repo.get_relations_for_entities(entity_names, row["tenant"])
 
     return _format_memory(
         row,
@@ -344,22 +347,21 @@ async def get_memories(
         include_entities: include entities linked to each memory
     """
     if len(memory_ids) > MAX_BULK_MEMORY_IDS:
-        return f"too many memory ids: max {MAX_BULK_MEMORY_IDS}, got {len(memory_ids)}"
+        raise ToolError(f"too many memory ids: max {MAX_BULK_MEMORY_IDS}, got {len(memory_ids)}")
 
+    pg = _get_pg()
     valid_ids, invalid_ids = _parse_memory_ids(memory_ids)
     rows = []
     if valid_ids:
-        pg = _get_pg()
         mem_repo = MemoryRepository(pg)
         rows = await mem_repo.get_by_ids(valid_ids)
     by_id = {str(row["id"]): row for row in rows}
 
     entities_by_id: dict[str, list[dict[str, Any]]] = {}
     if include_entities and rows:
-        pg = _get_pg()
         ent_repo = EntityRepository(pg)
-        for row in rows:
-            entities_by_id[str(row["id"])] = await ent_repo.get_memory_entities(row["id"])
+        grouped = await ent_repo.get_entities_for_memories([row["id"] for row in rows])
+        entities_by_id = {str(memory_id): entities for memory_id, entities in grouped.items()}
 
     output = []
     invalid = set(invalid_ids)

--- a/tests/unit/test_memory_retrieval_tools.py
+++ b/tests/unit/test_memory_retrieval_tools.py
@@ -1,0 +1,112 @@
+"""Tests for full-memory retrieval tools used after recall."""
+
+from __future__ import annotations
+
+from psycopg.types.json import Jsonb
+
+from synapto import server
+from synapto.db.migrations import run_migrations
+from synapto.repositories.entities import EntityRepository
+from synapto.repositories.memories import MemoryRepository
+
+TENANT = "test_memory_retrieval_tools"
+
+
+async def _cleanup(pg):
+    await pg.execute(
+        "DELETE FROM memory_entities WHERE memory_id IN (SELECT id FROM memories WHERE tenant = %s);",
+        (TENANT,),
+    )
+    await pg.execute("DELETE FROM memories WHERE tenant = %s;", (TENANT,))
+    await pg.execute(
+        "DELETE FROM relations WHERE from_entity_id IN (SELECT id FROM entities WHERE tenant = %s);",
+        (TENANT,),
+    )
+    await pg.execute("DELETE FROM entities WHERE tenant = %s;", (TENANT,))
+
+
+async def _insert_memory(pg, provider, content: str, *, summary: str | None = None):
+    emb = await provider.embed_one(content)
+    row = await pg.execute_one(
+        """
+        INSERT INTO memories (content, summary, embedding, embedding_dim, type, tenant, depth_layer, metadata)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s) RETURNING id;
+        """,
+        (
+            content,
+            summary,
+            emb,
+            provider.dimension,
+            "reference",
+            TENANT,
+            "stable",
+            Jsonb({"source": "test"}),
+        ),
+    )
+    return row["id"]
+
+
+async def test_memory_repository_get_by_id_returns_full_record(pg, provider):
+    await run_migrations(pg)
+    await _cleanup(pg)
+    memory_id = await _insert_memory(pg, provider, "full content survives retrieval", summary="full")
+
+    row = await MemoryRepository(pg).get_by_id(memory_id)
+
+    assert row is not None
+    assert row["id"] == memory_id
+    assert row["content"] == "full content survives retrieval"
+    assert row["summary"] == "full"
+    assert row["metadata"] == {"source": "test"}
+
+    await _cleanup(pg)
+
+
+async def test_get_memory_returns_complete_content_and_entities(pg, provider, monkeypatch):
+    await run_migrations(pg)
+    await _cleanup(pg)
+    content = "Production database access via StrongDM. " + ("details " * 60)
+    memory_id = await _insert_memory(pg, provider, content, summary="prod access")
+
+    ent_repo = EntityRepository(pg)
+    entity_id = await ent_repo.upsert("StrongDM", tenant=TENANT)
+    await ent_repo.link_memory(memory_id, entity_id)
+    monkeypatch.setattr(server, "_pg", pg)
+
+    output = await server.get_memory(str(memory_id))
+
+    assert f"id: {memory_id}" in output
+    assert "tenant: test_memory_retrieval_tools" in output
+    assert "summary: prod access" in output
+    assert "entities: StrongDM" in output
+    assert "details details details" in output
+
+    await _cleanup(pg)
+
+
+async def test_get_memories_preserves_requested_order_and_reports_missing(pg, provider, monkeypatch):
+    await run_migrations(pg)
+    await _cleanup(pg)
+    first_id = await _insert_memory(pg, provider, "first memory")
+    second_id = await _insert_memory(pg, provider, "second memory")
+    missing_id = "00000000-0000-0000-0000-000000000000"
+    monkeypatch.setattr(server, "_pg", pg)
+
+    output = await server.get_memories([str(second_id), missing_id, str(first_id), "not-a-uuid"])
+
+    second_pos = output.index(f"id: {second_id}")
+    missing_pos = output.index(f"memory {missing_id}: not found or deleted")
+    first_pos = output.index(f"id: {first_id}")
+    invalid_pos = output.index("memory not-a-uuid: invalid id")
+
+    assert second_pos < missing_pos < first_pos < invalid_pos
+
+    await _cleanup(pg)
+
+
+async def test_get_memories_enforces_bulk_limit():
+    ids = ["00000000-0000-0000-0000-000000000000"] * (server.MAX_BULK_MEMORY_IDS + 1)
+
+    output = await server.get_memories(ids)
+
+    assert f"too many memory ids: max {server.MAX_BULK_MEMORY_IDS}" in output

--- a/tests/unit/test_memory_retrieval_tools.py
+++ b/tests/unit/test_memory_retrieval_tools.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+from fastmcp.exceptions import ToolError
 from psycopg.types.json import Jsonb
 
 from synapto import server
 from synapto.db.migrations import run_migrations
 from synapto.repositories.entities import EntityRepository
 from synapto.repositories.memories import MemoryRepository
+from synapto.repositories.relations import RelationRepository
 
 TENANT = "test_memory_retrieval_tools"
 
@@ -84,6 +90,28 @@ async def test_get_memory_returns_complete_content_and_entities(pg, provider, mo
     await _cleanup(pg)
 
 
+async def test_get_memory_fetches_relations_in_batch(pg, provider, monkeypatch):
+    await run_migrations(pg)
+    await _cleanup(pg)
+    memory_id = await _insert_memory(pg, provider, "StrongDM exposes Divergence read-only access")
+
+    ent_repo = EntityRepository(pg)
+    strongdm_id = await ent_repo.upsert("StrongDM", tenant=TENANT)
+    divergence_id = await ent_repo.upsert("Divergence", tenant=TENANT)
+    await ent_repo.link_memory(memory_id, strongdm_id)
+    await ent_repo.link_memory(memory_id, divergence_id)
+    await RelationRepository(pg).upsert_by_name("StrongDM", "Divergence", "provides", TENANT)
+    monkeypatch.setattr(server, "_pg", pg)
+
+    output = await server.get_memory(str(memory_id), include_entities=False, include_relations=True)
+
+    assert "relations:" in output
+    assert "StrongDM --[provides]--> Divergence" in output
+    assert "entities:" not in output
+
+    await _cleanup(pg)
+
+
 async def test_get_memories_preserves_requested_order_and_reports_missing(pg, provider, monkeypatch):
     await run_migrations(pg)
     await _cleanup(pg)
@@ -104,9 +132,56 @@ async def test_get_memories_preserves_requested_order_and_reports_missing(pg, pr
     await _cleanup(pg)
 
 
+async def test_get_memories_batches_entities_for_all_rows(pg, provider, monkeypatch):
+    await run_migrations(pg)
+    await _cleanup(pg)
+    first_id = await _insert_memory(pg, provider, "first memory")
+    second_id = await _insert_memory(pg, provider, "second memory")
+
+    ent_repo = EntityRepository(pg)
+    first_entity_id = await ent_repo.upsert("FirstEntity", tenant=TENANT)
+    second_entity_id = await ent_repo.upsert("SecondEntity", tenant=TENANT)
+    await ent_repo.link_memory(first_id, first_entity_id)
+    await ent_repo.link_memory(second_id, second_entity_id)
+    monkeypatch.setattr(server, "_pg", pg)
+
+    output = await server.get_memories([str(first_id), str(second_id)], include_entities=True)
+
+    assert "entities: FirstEntity" in output
+    assert "entities: SecondEntity" in output
+
+    await _cleanup(pg)
+
+
 async def test_get_memories_enforces_bulk_limit():
     ids = ["00000000-0000-0000-0000-000000000000"] * (server.MAX_BULK_MEMORY_IDS + 1)
 
-    output = await server.get_memories(ids)
+    with pytest.raises(ToolError, match=f"too many memory ids: max {server.MAX_BULK_MEMORY_IDS}"):
+        await server.get_memories(ids)
 
-    assert f"too many memory ids: max {server.MAX_BULK_MEMORY_IDS}" in output
+
+async def test_recall_preview_zero_uses_explicit_elision_marker(monkeypatch):
+    async def fake_hybrid_search(*args, **kwargs):
+        return [
+            SimpleNamespace(
+                id="00000000-0000-0000-0000-000000000001",
+                content="hidden content",
+                type="reference",
+                tenant=TENANT,
+                depth_layer="stable",
+                decay_score=1.0,
+                trust_score=0.5,
+                rrf_score=0.1,
+                created_at=datetime(2026, 5, 5, tzinfo=UTC),
+            )
+        ]
+
+    monkeypatch.setattr(server, "_pg", object())
+    monkeypatch.setattr(server, "_provider", object())
+    monkeypatch.setattr(server, "_config", SimpleNamespace(default_tenant=TENANT))
+    monkeypatch.setattr(server, "hybrid_search", fake_hybrid_search)
+
+    output = await server.recall("anything", preview_chars=0)
+
+    assert server.RECALL_CONTENT_ELIDED in output
+    assert "hidden content" not in output

--- a/tests/unit/test_tool_metadata.py
+++ b/tests/unit/test_tool_metadata.py
@@ -12,6 +12,8 @@ DEFERRED_TOOLS = (
     "forget",
     "trust_feedback",
     "find_contradictions",
+    "get_memory",
+    "get_memories",
     "graph_query",
     "list_entities_tool",
     "memory_stats",
@@ -27,9 +29,7 @@ def test_always_load_meta_constant_shape():
 async def test_critical_tools_carry_always_load_meta(name: str):
     """`remember` and `recall` must ship `alwaysLoad: true` so MCP clients skip ToolSearch."""
     tool = await mcp.get_tool(name)
-    assert tool.meta == ALWAYS_LOAD_META, (
-        f"{name!r} must expose alwaysLoad metadata so Claude Code loads it eagerly"
-    )
+    assert tool.meta == ALWAYS_LOAD_META, f"{name!r} must expose alwaysLoad metadata so Claude Code loads it eagerly"
 
 
 @pytest.mark.parametrize("name", DEFERRED_TOOLS)


### PR DESCRIPTION
## Summary
- add get_memory and get_memories MCP tools for two-stage retrieval after recall
- add recall preview_chars plus tenant and created_at in recall previews
- add repository read helpers, docs, and tests for full-memory retrieval

## Tests
- .venv/bin/ruff check src/synapto/repositories/memories.py src/synapto/search/hybrid.py src/synapto/server.py tests/unit/test_memory_retrieval_tools.py tests/unit/test_tool_metadata.py
- .venv/bin/pytest tests/unit/test_memory_retrieval_tools.py tests/unit/test_tool_metadata.py tests/unit/test_search_and_graph.py::TestHybridSearch::test_finds_semantically_similar tests/unit/test_search_and_graph.py::TestVectorSearch::test_returns_results_with_similarity
- .venv/bin/pytest (171 passed, 1 failed due local synapto_migrations state: get_schema_version returned 3 where the existing migration test expects 2)