### PR TITLE
chore(release): prepare Synapto 0.2.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,6 @@ jobs:
 
             or with auto-updates (recommended):
             ```json
-            { "command": "uvx", "args": ["synapto", "serve"] }
+            { "command": "uvx", "args": ["--refresh", "synapto", "serve"] }
             ```
           files: dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-05-06
+
+### Added
+
+- **Claude Code memory migration parser** with auto-detection for imported native Claude Code memories, making `synapto import` easier to use with existing agent memory files.
+- **structured JSON logging foundation** via `structlog` + `orjson`, giving Synapto consistent machine-readable stderr logs.
+- **metrics primitives and instrumentation** including a process-wide registry, log backend, async timing helper, per-tool call counters, latency histograms, and a Postgres metrics backend for persisted tool telemetry.
+- **full MCP memory retrieval** via `get_memory` and `get_memories`, enabling two-stage retrieval where `recall` can return compact previews and agents can fetch complete content only for selected memories.
+- **configurable recall previews** with `preview_chars`, plus `tenant` and `created_at` in recall output so agents can disambiguate results before fetching full records.
+
+### Fixed
+
+- **FastMCP startup banner suppression** for `synapto serve`; the Rich banner and update notice no longer pollute stderr with non-JSON lines, preserving structured log hygiene for MCP stdio deployments (#28).
+- **Postgres telemetry backend shutdown behavior** now drains or cancels in-flight writes before the pool closes, rejects late emits after shutdown, and resets the process registry during server teardown.
+- **metrics retention purge efficiency** by using the database cursor row count instead of materializing every deleted metric ID in Python.
+- **deterministic metric listing** by ordering equal timestamps with `id DESC`.
+- **migration test isolation** for temporary test migrations, avoiding stale local rows from interrupted test runs.
+
+### Security
+
+- **CI dependency audit stability** by constraining `pip>=26.1` in the development extras to avoid the known vulnerable pip version bundled by older uv-created environments.
+
 ### Documentation
 
 - **install snippets use `uvx --refresh`** so users actually receive new releases on Claude Code / Cursor restart — the previous snippets relied on `uvx` reusing its package cache, which meant a published Synapto release could go unnoticed until the cache expired. README, `docs/claude-code.md`, and `docs/cursor.md` now recommend the `--refresh` flag, document the startup tradeoff, and describe the manual `uv cache clean synapto` escape hatch. Also explains why a full Claude Code quit is required to pick up a new version mid-session.
+- **release notes auto-update snippet** now also recommends `uvx --refresh`, matching the install docs.
 
 ## [0.2.0] - 2026-04-22
 

--- a/src/synapto/cli.py
+++ b/src/synapto/cli.py
@@ -138,7 +138,10 @@ def init(pg_dsn: str, interactive: bool) -> None:
 def serve() -> None:
     """Start the Synapto MCP server (stdio transport)."""
     from synapto.server import mcp
-    mcp.run()
+
+    # Keep stderr machine-readable. FastMCP's Rich banner bypasses logging and
+    # otherwise pollutes the JSON log stream used by MCP stdio deployments.
+    mcp.run(show_banner=False)
 
 
 @main.command()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 
+from click.testing import CliRunner
+
 from synapto.cli import _detect_mcp_clients, _write_mcp_config
 
 
@@ -90,3 +92,23 @@ class TestWriteMcpConfig:
         assert config_path.exists()
         data = json.loads(config_path.read_text())
         assert data["mcpServers"]["synapto"]["command"] == "uvx"
+
+
+class TestServeCommand:
+    def test_serve_disables_fastmcp_banner(self, monkeypatch):
+        """FastMCP's Rich banner bypasses logging, so serve must suppress it."""
+        from synapto import server
+        from synapto.cli import main
+
+        calls = []
+
+        class DummyMCP:
+            def run(self, **kwargs):
+                calls.append(kwargs)
+
+        monkeypatch.setattr(server, "mcp", DummyMCP())
+
+        result = CliRunner().invoke(main, ["serve"])
+
+        assert result.exit_code == 0
+        assert calls == [{"show_banner": False}]


### PR DESCRIPTION
## Summary

Prepare the patch release we discussed after merging the telemetry Postgres backend:

- suppress FastMCP's Rich startup banner for `synapto serve` by passing `show_banner=False`
- add a CLI test that locks the banner suppression behavior
- add `CHANGELOG.md` entries for `0.2.1`
- align the GitHub release body with the documented `uvx --refresh` install snippet

Closes #28.

## Release note

This PR does not bump `pyproject.toml` or `src/synapto/__init__.py`; the existing release workflow owns that when we dispatch `bump_type=patch` after merge.

## Test plan

- `uv run ruff check src/ tests/`
- `uv run pytest tests/ -q` -> 188 passed
