### PR TITLE
chore(release): bump version to 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "synapto"
-version = "0.2.0"
+version = "0.2.1"
 description = "Persistent memory graph for AI coding agents — semantic search, knowledge graph, and time-based decay over MCP"
 readme = "README.md"
 license = "MIT"

--- a/src/synapto/__init__.py
+++ b/src/synapto/__init__.py
@@ -1,3 +1,3 @@
 """Synapto — persistent memory graph for AI coding agents."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/uv.lock
+++ b/uv.lock
@@ -2814,7 +2814,7 @@ wheels = [
 
 [[package]]
 name = "synapto"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
## Summary

The release workflow failed before publishing because `main` is protected and rejects direct pushes from the workflow version-bump step.

This PR moves the version bump through the required PR path:

- bump `pyproject.toml` from `0.2.0` to `0.2.1`
- bump `src/synapto/__init__.py` from `0.2.0` to `0.2.1`
- refresh `uv.lock` for the local package version

After this merges, run the existing `release` workflow with `bump_type=current` so it builds, tags `v0.2.1`, publishes to PyPI, and creates the GitHub Release without trying to push another commit to protected `main`.

## Test plan

- `uv run python -m build`
- `uv run python - <<'PY'` / `import synapto; print(synapto.__version__)` -> `0.2.1`
