### PR TITLE
feat(mcp): add incremental memory updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Restart your agent. Synapto tools appear automatically, and any future release w
 | `recall` | Search memories by meaning |
 | `get_memory` | Fetch the complete content and metadata for one recalled memory |
 | `get_memories` | Fetch complete content for multiple recalled memories |
+| `update_memory` | Replace, append, or patch fields on an existing memory |
 | `relate` | Link two entities ("Hermes" --[produces]--> "agent.messages") |
 | `forget` | Soft-delete a memory |
 | `trust_feedback` | Mark a memory as helpful or unhelpful |
@@ -143,6 +144,21 @@ Restart your agent. Synapto tools appear automatically, and any future release w
 | `list_entities` | Browse known entities |
 | `memory_stats` | View counts and distribution |
 | `maintain` | Run decay and cleanup |
+
+### Tool Field Limits
+
+Synapto validates known hard limits before hitting the database, so MCP clients
+get actionable errors instead of raw Postgres exceptions.
+
+| Field | Limit |
+|------|-------|
+| `content` | Text; no Synapto length limit |
+| `summary` | Max 255 characters |
+| `memory_type` | Max 20 characters |
+| `depth_layer` | Max 20 characters |
+| `tenant` | Max 100 characters |
+| `get_memories.memory_ids` | Max 20 IDs per call |
+| `recall.preview_chars` | Clamped to 0-1000 characters |
 
 ## CLI
 

--- a/docs/handoffs.md
+++ b/docs/handoffs.md
@@ -39,6 +39,10 @@ and receiver are never online at the same time.
 4. **Follow up** — progress is appended as a new memory with the same `task_id`;
    older handoffs are not mutated.
 
+Use `update_memory` for small corrections or appending clarifying text to a
+single memory. For state transitions between agents, prefer a new follow-up
+memory so the coordination trail stays auditable.
+
 ## Storage Model
 
 The MVP stores handoffs in the existing `memories` table:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
     # pinned to fix CVE-2026-42561 in python-multipart, pulled transitively
     # by the MCP/FastAPI stack.
     "python-multipart>=0.0.27",
+    # pinned to fix CVE-2026-44431/CVE-2026-44432, pulled transitively.
+    "urllib3>=2.7.0",
     "psycopg[binary,pool]>=3.1",
     "pgvector>=0.3.0",
     "redis>=5.0",

--- a/src/synapto/prompts/server_instructions.md
+++ b/src/synapto/prompts/server_instructions.md
@@ -36,6 +36,8 @@ Cross-agent handoffs:
   `metadata.task_id` after fetching the full memory.
 - Treat `files_scope` as an advisory claim. Do not edit outside it unless the
   user expands the scope. Append follow-up memories instead of mutating old ones.
+- Use `update_memory` for narrow corrections, summary fixes, metadata patches,
+  or appending clarifying text to an existing memory.
 
 Depth layers control decay:
 - core: forever (rules, identity)
@@ -44,4 +46,4 @@ Depth layers control decay:
 - ephemeral: hours (short-lived state)
 
 If `recall` returns a memory that conflicts with what you observe now, trust the
-current state and update or `forget` the stale memory.
+current state and call `update_memory` or `forget` for the stale memory.

--- a/src/synapto/repositories/entities.py
+++ b/src/synapto/repositories/entities.py
@@ -42,6 +42,8 @@ _LINK_MEMORY = """
     VALUES (%s, %s) ON CONFLICT DO NOTHING;
 """
 
+_UNLINK_MEMORY_ENTITIES = "DELETE FROM memory_entities WHERE memory_id = %s;"
+
 _GET_MEMORY_ENTITIES = """
     SELECT e.id, e.name, e.entity_type
     FROM entities e
@@ -117,6 +119,11 @@ class EntityRepository:
 
     async def link_memory(self, memory_id: UUID, entity_id: UUID) -> None:
         await self._db.execute(_LINK_MEMORY, (memory_id, entity_id))
+
+    async def replace_memory_links(self, memory_id: UUID, entity_ids: list[UUID]) -> None:
+        await self._db.execute(_UNLINK_MEMORY_ENTITIES, (memory_id,))
+        if entity_ids:
+            await self._db.execute_many(_LINK_MEMORY, [(memory_id, entity_id) for entity_id in entity_ids])
 
     async def get_memory_entities(self, memory_id: UUID) -> list[dict[str, Any]]:
         return await self._db.execute(_GET_MEMORY_ENTITIES, (memory_id,))

--- a/src/synapto/repositories/memories.py
+++ b/src/synapto/repositories/memories.py
@@ -61,6 +61,34 @@ _GET_BY_IDS = """
 
 _UPDATE_HRR = "UPDATE memories SET hrr_vector = %s, hrr_dim = %s WHERE id = %s;"
 
+_UPDATE_MEMORY = """
+    UPDATE memories
+    SET
+        content = CASE WHEN %(content_provided)s THEN %(content)s ELSE content END,
+        summary = CASE WHEN %(summary_provided)s THEN %(summary)s ELSE summary END,
+        embedding = CASE WHEN %(embedding_provided)s THEN %(emb)s::vector ELSE embedding END,
+        embedding_dim = CASE WHEN %(dim_provided)s THEN %(dim)s ELSE embedding_dim END,
+        metadata = CASE
+            WHEN %(meta_provided)s THEN COALESCE(metadata, '{}'::jsonb) || %(meta)s::jsonb
+            ELSE metadata
+        END,
+        accessed_at = now()
+    WHERE id = %(id)s AND deleted_at IS NULL
+    RETURNING
+        id,
+        content,
+        summary,
+        type,
+        tenant,
+        depth_layer,
+        metadata,
+        decay_score,
+        trust_score,
+        access_count,
+        created_at,
+        accessed_at;
+"""
+
 _SOFT_DELETE = """
     UPDATE memories SET deleted_at = now()
     WHERE id = %s AND deleted_at IS NULL
@@ -179,6 +207,33 @@ class MemoryRepository:
 
     async def update_hrr(self, memory_id: UUID, hrr_vector: bytes, hrr_dim: int) -> None:
         await self._db.execute(_UPDATE_HRR, (hrr_vector, hrr_dim, memory_id))
+
+    async def update(
+        self,
+        memory_id: str | UUID,
+        *,
+        content: str | None = None,
+        embedding: list[float] | None = None,
+        embedding_dim: int | None = None,
+        summary: str | None = None,
+        metadata_patch: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        return await self._db.execute_one(
+            _UPDATE_MEMORY,
+            {
+                "id": memory_id,
+                "content_provided": content is not None,
+                "content": content,
+                "summary_provided": summary is not None,
+                "summary": summary,
+                "embedding_provided": embedding is not None,
+                "emb": embedding,
+                "dim_provided": embedding_dim is not None,
+                "dim": embedding_dim,
+                "meta_provided": metadata_patch is not None,
+                "meta": Jsonb(metadata_patch or {}),
+            },
+        )
 
     async def get_by_id(self, memory_id: str | UUID) -> dict[str, Any] | None:
         return await self._db.execute_one(_GET_BY_ID, (memory_id,))

--- a/src/synapto/server.py
+++ b/src/synapto/server.py
@@ -124,6 +124,10 @@ ALWAYS_LOAD_META = {"alwaysLoad": True}
 MAX_RECALL_PREVIEW_CHARS = 1000
 DEFAULT_RECALL_PREVIEW_CHARS = 200
 MAX_BULK_MEMORY_IDS = 20
+MAX_SUMMARY_CHARS = 255
+MAX_MEMORY_TYPE_CHARS = 20
+MAX_TENANT_CHARS = 100
+MAX_DEPTH_LAYER_CHARS = 20
 RECALL_CONTENT_ELIDED = "[content elided - fetch full via get_memory(id)]"
 
 
@@ -145,6 +149,33 @@ def _format_timestamp(value: datetime | None) -> str:
 
 def _format_json(value: dict[str, Any] | None) -> str:
     return json.dumps(value or {}, ensure_ascii=False, sort_keys=True)
+
+
+def _validate_max_chars(field: str, value: str | None, max_chars: int, *, guidance: str | None = None) -> None:
+    if value is None or len(value) <= max_chars:
+        return
+    message = f"{field} exceeds {max_chars} chars (got {len(value)})"
+    if guidance:
+        message += f" — {guidance}"
+    raise ToolError(message)
+
+
+def _validate_memory_fields(
+    *,
+    memory_type: str | None = None,
+    tenant: str | None = None,
+    depth_layer: str | None = None,
+    summary: str | None = None,
+) -> None:
+    _validate_max_chars("memory_type", memory_type, MAX_MEMORY_TYPE_CHARS)
+    _validate_max_chars("tenant", tenant, MAX_TENANT_CHARS)
+    _validate_max_chars("depth_layer", depth_layer, MAX_DEPTH_LAYER_CHARS)
+    _validate_max_chars(
+        "summary",
+        summary,
+        MAX_SUMMARY_CHARS,
+        guidance="pass the full text via 'content' and a short headline via 'summary'",
+    )
 
 
 def _format_memory(
@@ -329,17 +360,20 @@ async def remember(
     """Store a memory with optional entity extraction.
 
     Args:
-        content: the memory content to store
-        memory_type: category (general, user, feedback, project, reference)
-        tenant: project/tenant scope (defaults to config default)
-        depth_layer: core, stable, working, or ephemeral
-        summary: optional short summary
+        content: memory content to store (text; no Synapto length limit)
+        memory_type: category (general, user, feedback, project, reference; max 20 chars)
+        tenant: project/tenant scope (defaults to config default; max 100 chars)
+        depth_layer: core, stable, working, or ephemeral (max 20 chars)
+        summary: optional short summary (max 255 chars)
         metadata: optional JSON metadata
         extract_entities: auto-extract and link entities from content
     """
+    _validate_memory_fields(memory_type=memory_type, tenant=tenant, depth_layer=depth_layer, summary=summary)
+
     pg = _get_pg()
     provider = _get_provider()
     t = tenant or _config.default_tenant
+    _validate_memory_fields(tenant=t)
     repo = MemoryRepository(pg)
 
     embedding = await provider.embed_one(content)
@@ -374,6 +408,97 @@ async def remember(
 
     entity_count = len(entity_names)
     return f"stored memory {memory_id} ({depth_layer}, {entity_count} entities linked)"
+
+
+@mcp.tool
+@instrumented_tool
+async def update_memory(
+    memory_id: str,
+    content: str | None = None,
+    summary: str | None = None,
+    metadata_patch: dict[str, Any] | None = None,
+    append: str | None = None,
+) -> str:
+    """Update an existing memory without re-sending the whole record.
+
+    Args:
+        memory_id: UUID of the memory to update
+        content: replacement memory content (text; no Synapto length limit)
+        summary: optional replacement summary (max 255 chars)
+        metadata_patch: optional JSON object shallow-merged into existing metadata
+        append: text appended to the existing content (mutually exclusive with content)
+    """
+    if content is not None and append is not None:
+        raise ToolError("content and append are mutually exclusive; provide one or the other")
+    if content is None and summary is None and metadata_patch is None and append is None:
+        raise ToolError("provide at least one field to update")
+    if metadata_patch is not None and not isinstance(metadata_patch, dict):
+        raise ToolError("metadata_patch must be a JSON object")
+
+    _validate_memory_fields(summary=summary)
+
+    try:
+        parsed_id = UUID(memory_id)
+    except ValueError:
+        return f"invalid memory id: {memory_id}"
+
+    pg = _get_pg()
+    repo = MemoryRepository(pg)
+    row = await repo.get_by_id(parsed_id)
+    if not row:
+        return f"memory {memory_id} not found or deleted"
+
+    new_content = content
+    if append is not None:
+        new_content = row["content"] + append
+
+    embedding = None
+    embedding_dim = None
+    if new_content is not None:
+        provider = _get_provider()
+        embedding = await provider.embed_one(new_content)
+        embedding_dim = provider.dimension
+
+    updated = await repo.update(
+        parsed_id,
+        content=new_content,
+        embedding=embedding,
+        embedding_dim=embedding_dim,
+        summary=summary,
+        metadata_patch=metadata_patch,
+    )
+    if not updated:
+        return f"memory {memory_id} not found or deleted"
+
+    if new_content is not None:
+        entity_names = extract_entities_from_text(new_content)
+        provider = _get_provider()
+        ent_repo = EntityRepository(pg)
+        entity_ids = []
+        for entity_name in entity_names:
+            eid = await create_entity(pg, entity_name, "concept", updated["tenant"], provider=provider)
+            entity_ids.append(eid)
+        await ent_repo.replace_memory_links(parsed_id, entity_ids)
+
+        try:
+            hrr_vec = encode_fact(new_content, entity_names)
+            await repo.update_hrr(parsed_id, phases_to_bytes(hrr_vec), DEFAULT_DIM)
+            bank_name = f"{updated['tenant']}:{updated['type']}"
+            await rebuild_bank(pg, bank_name, updated["tenant"], type_filter=updated["type"])
+        except Exception as e:
+            logger.warning("post-update hrr refresh failed for %s: %s", parsed_id, e)
+
+    cache = _get_cache()
+    await cache.invalidate_memory(parsed_id)
+
+    changed = []
+    if new_content is not None:
+        changed.append("content")
+    if summary is not None:
+        changed.append("summary")
+    if metadata_patch is not None:
+        changed.append("metadata")
+    return f"updated memory {parsed_id} ({', '.join(changed)})"
 
 
 @mcp.tool(meta=ALWAYS_LOAD_META)

--- a/tests/unit/test_memory_retrieval_tools.py
+++ b/tests/unit/test_memory_retrieval_tools.py
@@ -18,6 +18,14 @@ from synapto.repositories.relations import RelationRepository
 TENANT = "test_memory_retrieval_tools"
 
 
+class DummyCache:
+    def __init__(self) -> None:
+        self.invalidated = []
+
+    async def invalidate_memory(self, memory_id):
+        self.invalidated.append(memory_id)
+
+
 async def _cleanup(pg):
     await pg.execute(
         "DELETE FROM memory_entities WHERE memory_id IN (SELECT id FROM memories WHERE tenant = %s);",
@@ -66,6 +74,117 @@ async def test_memory_repository_get_by_id_returns_full_record(pg, provider):
     assert row["metadata"] == {"source": "test"}
 
     await _cleanup(pg)
+
+
+async def test_memory_repository_update_merges_partial_fields(pg, provider):
+    await run_migrations(pg)
+    await _cleanup(pg)
+    memory_id = await _insert_memory(pg, provider, "original content", summary="old summary")
+
+    row = await MemoryRepository(pg).update(
+        memory_id,
+        summary="new summary",
+        metadata_patch={"status": "updated", "reviewed": True},
+    )
+
+    assert row is not None
+    assert row["id"] == memory_id
+    assert row["content"] == "original content"
+    assert row["summary"] == "new summary"
+    assert row["metadata"] == {"source": "test", "status": "updated", "reviewed": True}
+
+    await _cleanup(pg)
+
+
+async def test_update_memory_appends_content_and_invalidates_cache(pg, provider, monkeypatch):
+    await run_migrations(pg)
+    await _cleanup(pg)
+    memory_id = await _insert_memory(pg, provider, "first paragraph", summary="append target")
+    cache = DummyCache()
+    monkeypatch.setattr(server, "_pg", pg)
+    monkeypatch.setattr(server, "_provider", provider)
+    monkeypatch.setattr(server, "_cache", cache)
+
+    output = await server.update_memory(str(memory_id), append="\nsecond paragraph")
+
+    row = await MemoryRepository(pg).get_by_id(memory_id)
+    assert row is not None
+    assert row["content"] == "first paragraph\nsecond paragraph"
+    assert f"updated memory {memory_id}" in output
+    assert memory_id in cache.invalidated
+
+    await _cleanup(pg)
+
+
+async def test_update_memory_replaces_entity_links_for_replaced_content(pg, provider, monkeypatch):
+    await run_migrations(pg)
+    await _cleanup(pg)
+    memory_id = await _insert_memory(pg, provider, "`OldEntity` is no longer relevant", summary="entity target")
+    ent_repo = EntityRepository(pg)
+    old_entity_id = await ent_repo.upsert("OldEntity", tenant=TENANT)
+    await ent_repo.link_memory(memory_id, old_entity_id)
+    cache = DummyCache()
+    monkeypatch.setattr(server, "_pg", pg)
+    monkeypatch.setattr(server, "_provider", provider)
+    monkeypatch.setattr(server, "_cache", cache)
+
+    await server.update_memory(str(memory_id), content="`NewEntity` is the only relevant entity now")
+
+    entities = await ent_repo.get_memory_entities(memory_id)
+    entity_names = {entity["name"] for entity in entities}
+    assert "NewEntity" in entity_names
+    assert "OldEntity" not in entity_names
+
+    await _cleanup(pg)
+
+
+async def test_update_memory_updates_summary_and_metadata_patch(pg, provider, monkeypatch):
+    await run_migrations(pg)
+    await _cleanup(pg)
+    memory_id = await _insert_memory(pg, provider, "unchanged content", summary="old summary")
+    cache = DummyCache()
+    monkeypatch.setattr(server, "_pg", pg)
+    monkeypatch.setattr(server, "_cache", cache)
+
+    output = await server.update_memory(
+        str(memory_id),
+        summary="new summary",
+        metadata_patch={"source": "updated", "status": "reviewed"},
+    )
+
+    row = await MemoryRepository(pg).get_by_id(memory_id)
+    assert row is not None
+    assert row["content"] == "unchanged content"
+    assert row["summary"] == "new summary"
+    assert row["metadata"] == {"source": "updated", "status": "reviewed"}
+    assert f"updated memory {memory_id} (summary, metadata)" in output
+    assert memory_id in cache.invalidated
+
+    await _cleanup(pg)
+
+
+async def test_update_memory_rejects_empty_patch():
+    with pytest.raises(ToolError, match="provide at least one field to update"):
+        await server.update_memory("00000000-0000-0000-0000-000000000000")
+
+
+async def test_update_memory_rejects_content_and_append_together():
+    with pytest.raises(ToolError, match="content and append are mutually exclusive"):
+        await server.update_memory(
+            "00000000-0000-0000-0000-000000000000",
+            content="replacement",
+            append="tail",
+        )
+
+
+async def test_remember_rejects_overlong_summary_before_database_access():
+    with pytest.raises(ToolError, match="summary exceeds 255 chars \\(got 256\\)"):
+        await server.remember("content", summary="x" * 256)
+
+
+async def test_update_memory_rejects_overlong_summary_before_database_access():
+    with pytest.raises(ToolError, match="summary exceeds 255 chars \\(got 256\\)"):
+        await server.update_memory("00000000-0000-0000-0000-000000000000", summary="x" * 256)
 
 
 async def test_get_memory_returns_complete_content_and_entities(pg, provider, monkeypatch):

--- a/tests/unit/test_tool_metadata.py
+++ b/tests/unit/test_tool_metadata.py
@@ -14,6 +14,7 @@ DEFERRED_TOOLS = (
     "find_contradictions",
     "get_memory",
     "get_memories",
+    "update_memory",
     "agent_handoff_template",
     "handoff_inbox_template",
     "graph_query",
@@ -40,3 +41,16 @@ async def test_non_critical_tools_stay_deferred(name: str):
     so they do not bloat the LLM's tool list on every session."""
     tool = await mcp.get_tool(name)
     assert tool.meta is None, f"{name!r} should not carry alwaysLoad metadata"
+
+
+async def test_memory_tool_descriptions_document_hard_limits():
+    remember = await mcp.get_tool("remember")
+    update_memory = await mcp.get_tool("update_memory")
+    get_memories = await mcp.get_tool("get_memories")
+
+    assert "summary: optional short summary (max 255 chars)" in remember.description
+    assert "memory_type" in remember.description and "max 20 chars" in remember.description
+    assert "tenant" in remember.description and "max 100 chars" in remember.description
+    assert "depth_layer" in remember.description and "max 20 chars" in remember.description
+    assert "summary: optional replacement summary (max 255 chars)" in update_memory.description
+    assert "memory_ids: UUIDs of memories to fetch (max 20)" in get_memories.description

--- a/uv.lock
+++ b/uv.lock
@@ -2830,6 +2830,7 @@ dependencies = [
     { name = "sentence-transformers" },
     { name = "structlog" },
     { name = "tomli-w" },
+    { name = "urllib3" },
 ]
 
 [package.optional-dependencies]
@@ -2872,6 +2873,7 @@ requires-dist = [
     { name = "structlog", specifier = ">=24.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
     { name = "tomli-w", specifier = ">=1.0" },
+    { name = "urllib3", specifier = ">=2.7.0" },
 ]
 provides-extras = ["openai", "dev"]
 
@@ -3127,11 +3129,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add `update_memory` for partial memory updates, metadata patches, and content append/replacement
- validate memory field length limits before database writes and document those limits in tool descriptions/docs
- refresh content-derived embedding/HRR/entity links after content updates and invalidate cache after updates
- pin `urllib3>=2.7.0` so the security job remains green after new pip-audit advisories

Closes #48

## Tests
- `uv run pytest tests/ -q`
- `uv run ruff check src/ tests/`
- `uv run bandit -r src/synapto/ -c pyproject.toml`
- `uv run pip-audit`
- `uv run ruff format --check src/synapto/server.py src/synapto/repositories/memories.py src/synapto/repositories/entities.py tests/unit/test_memory_retrieval_tools.py tests/unit/test_tool_metadata.py`

Note: full-project `ruff format --check src/ tests/` still reports pre-existing formatting drift in unrelated files, so this PR validates formatting only for touched Python files.