### PR TITLE
chore(release): prepare 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-10
+
+### Added
+
+- **incremental MCP memory updates** via `update_memory`, enabling agents to append to memory content, replace memory content, or patch memory metadata without re-sending the full record. Content updates refresh content-derived embedding, HRR, and entity links, while metadata-only updates avoid unnecessary recomputation.
+
+### Security
+
+- **dependency audit fixes** by constraining vulnerable transitive dependencies and dev-audit tooling dependencies: `idna>=3.15`, `starlette>=1.0.1`, `PyJWT>=2.13.0`, and `pip>=26.1.2`.
+
 ## [0.3.0] - 2026-05-11
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "synapto"
-version = "0.3.0"
+version = "0.4.0"
 description = "Persistent memory graph for AI coding agents — semantic search, knowledge graph, and time-based decay over MCP"
 readme = "README.md"
 license = "MIT"
@@ -39,6 +39,9 @@ dependencies = [
     "idna>=3.15",
     # pinned to fix PYSEC-2026-161, pulled transitively by the MCP/FastAPI stack.
     "starlette>=1.0.1",
+    # pinned to fix PYSEC-2026-175/PYSEC-2026-177/PYSEC-2026-178/PYSEC-2026-179,
+    # pulled transitively by the MCP stack.
+    "PyJWT>=2.13.0",
     "psycopg[binary,pool]>=3.1",
     "pgvector>=0.3.0",
     "redis>=5.0",
@@ -62,10 +65,11 @@ dev = [
     "bandit>=1.7",
     "pip-audit>=2.7",
     "build>=1.0",
-    # pinned to fix CVE-2026-3219 in pip itself; uv bundles 26.0.1 by default
+    # pinned to fix CVE-2026-3219/PYSEC-2026-196 in pip itself; uv bundles older
+    # pip versions by default
     # and pip-audit flags it. drop this constraint once uv ships a venv with
-    # pip>=26.1 out of the box.
-    "pip>=26.1",
+    # pip>=26.1.2 out of the box.
+    "pip>=26.1.2",
 ]
 
 [project.scripts]

--- a/src/synapto/__init__.py
+++ b/src/synapto/__init__.py
@@ -1,3 +1,3 @@
 """Synapto — persistent memory graph for AI coding agents."""
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1715,11 +1715,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1"
+version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/7e/d2b04004e1068ad4fdfa2f227b839b5d03e602e47cdbbf49de71137c9546/pip-26.1.tar.gz", hash = "sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3", size = 1840316, upload-time = "2026-04-26T21:00:05.406Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl", hash = "sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1", size = 1812804, upload-time = "2026-04-26T21:00:03.194Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]
@@ -2058,11 +2058,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]
@@ -2814,7 +2814,7 @@ wheels = [
 
 [[package]]
 name = "synapto"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },
@@ -2826,6 +2826,7 @@ dependencies = [
     { name = "pgvector" },
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "pydantic" },
+    { name = "pyjwt" },
     { name = "python-multipart" },
     { name = "redis" },
     { name = "sentence-transformers" },
@@ -2862,10 +2863,11 @@ requires-dist = [
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0" },
     { name = "orjson", specifier = ">=3.10" },
     { name = "pgvector", specifier = ">=0.3.0" },
-    { name = "pip", marker = "extra == 'dev'", specifier = ">=26.1" },
+    { name = "pip", marker = "extra == 'dev'", specifier = ">=26.1.2" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.7" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.1" },
     { name = "pydantic", specifier = ">=2.0" },
+    { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },


### PR DESCRIPTION
## Summary
- bump Synapto package version to 0.4.0
- document 0.4.0 release notes for incremental MCP memory updates and dependency audit fixes
- update uv.lock for the 0.4.0 package version, PyJWT 2.13.0, and pip 26.1.2

## Includes
- PR #52: feat(mcp): add incremental memory updates
- PR #53: fix(security): bump vulnerable transitive deps
- additional audit constraints for current pip-audit advisories: PyJWT>=2.13.0 and pip>=26.1.2

## Validation
- uv run ruff check src/ tests/
- uv run python -c 'import synapto; print(synapto.__version__)'
- uv run bandit -r src/synapto/ -c pyproject.toml
- uv sync --extra dev --python 3.13
- uv run pip-audit
- uv run pytest tests/ -q
- git diff --check
- uv run python -m build

After this PR merges, run the release workflow with bump_type=current.