### PR TITLE
feat(server): guide automatic memory capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,19 @@ Restart Claude Code after running the command so the MCP subprocess receives the
 
 Restart your agent. Synapto tools appear automatically, and any future release will be live on the next restart.
 
+## Default Memory Routing
+
+Synapto is designed to be the primary memory sink for MCP-compatible agents. Agents should call `recall` before non-trivial work and call `remember` when users provide durable context instead of writing new memory into flat files.
+
+| User signal | Tool action | Recommended type/layer |
+|-------------|-------------|------------------------|
+| "always X", "never Y", "from now on" | Store as a rule | `feedback` / `core` |
+| "don't do X", "that's wrong" | Store as a correction | `feedback` / `core` |
+| "we use X for Y", "our architecture is..." | Store as project context | `project` / `stable` |
+| "this sprint", "current PR", "release plan" | Store as active work | `project` / `working` |
+| "tracked in Linear", "dashboard is..." | Store as external reference | `reference` / `stable` |
+| "I work on...", "my preference is..." | Store as user context | `user` / `stable` |
+
 ## MCP Tools
 
 | Tool | What it does |

--- a/src/synapto/server.py
+++ b/src/synapto/server.py
@@ -359,6 +359,29 @@ async def remember(
 ) -> str:
     """Store a memory with optional entity extraction.
 
+    IMPORTANT: Use this tool whenever the user gives a durable preference,
+    correction, workflow rule, project context, architecture note, external
+    system reference, identity detail, or explicitly asks you to remember
+    something. Store the memory in Synapto instead of writing flat files such
+    as MEMORY.md or CLAUDE.md notes.
+
+    Recommended memory_type choices:
+    - feedback: user preferences, corrections, workflow rules, code style,
+      testing expectations, communication rules.
+    - project: project-specific architecture, decisions, active work, release
+      plans, repository conventions.
+    - reference: external systems, dashboards, docs, URLs, credentials
+      locations, operational runbooks.
+    - user: long-lived details about the user's role, constraints, expertise,
+      or personal preferences.
+    - general: useful context that does not fit another category.
+
+    Recommended depth_layer choices:
+    - core: rules that should not expire, such as "always" or "never" feedback.
+    - stable: context expected to last months, such as architecture decisions.
+    - working: active tasks, current sprint/release work, or handoffs.
+    - ephemeral: short-lived debugging notes and temporary observations.
+
     Args:
         content: memory content to store (text; no Synapto length limit)
         memory_type: category (general, user, feedback, project, reference; max 20 chars)
@@ -511,6 +534,17 @@ async def recall(
     preview_chars: int = DEFAULT_RECALL_PREVIEW_CHARS,
 ) -> str:
     """Search memories using hybrid semantic + keyword search with RRF ranking.
+
+    IMPORTANT: Call this tool at the start of any non-trivial task to load
+    relevant context before acting. Also call it whenever the user references
+    prior decisions, history, preferences, project context, "remember", or
+    "what do we know about" style questions. Recall proactively rather than
+    waiting for the user to ask.
+
+    Use tenant to scope project-specific memory and depth_layer to narrow the
+    result set when you need only core rules, stable architecture, working task
+    context, or ephemeral debugging notes. Follow up with get_memory when a
+    recalled result needs full content, metadata, or linked entities.
 
     Args:
         query: natural language search query

--- a/tests/unit/test_tool_metadata.py
+++ b/tests/unit/test_tool_metadata.py
@@ -54,3 +54,39 @@ async def test_memory_tool_descriptions_document_hard_limits():
     assert "depth_layer" in remember.description and "max 20 chars" in remember.description
     assert "summary: optional replacement summary (max 255 chars)" in update_memory.description
     assert "memory_ids: UUIDs of memories to fetch (max 20)" in get_memories.description
+
+
+async def test_remember_description_guides_automatic_memory_capture():
+    remember = await mcp.get_tool("remember")
+
+    for phrase in (
+        "durable preference",
+        "workflow rule",
+        "project context",
+        "Store the memory in Synapto instead of writing flat files",
+        "Recommended memory_type choices",
+        "Recommended depth_layer choices",
+        "feedback",
+        "project",
+        "reference",
+        "user",
+        "core",
+        "stable",
+        "working",
+        "ephemeral",
+    ):
+        assert phrase in remember.description
+
+
+async def test_recall_description_guides_proactive_context_loading():
+    recall = await mcp.get_tool("recall")
+
+    for phrase in (
+        "at the start of any non-trivial task",
+        "prior decisions",
+        "preferences",
+        "Recall proactively",
+        "Use tenant to scope project-specific memory",
+        "Follow up with get_memory",
+    ):
+        assert phrase in recall.description


### PR DESCRIPTION
## Summary
- expand `remember` tool description with durable-memory triggers, memory_type guidance, and depth_layer guidance
- expand `recall` tool description to encourage proactive context loading before non-trivial tasks
- document default memory routing patterns in the README
- add tests that lock the automatic-capture guidance into MCP tool descriptions

## Release plan
- Target: v0.5.0 source-of-truth / governed context layer
- Closes #7

## Validation
- `git diff --check`
- `uv run pytest tests/unit/test_tool_metadata.py tests/unit/test_server_instructions.py -q` (25 passed)
- `uv run pytest tests/unit -q` (238 passed)
- `uv run ruff check src/ tests/`
- GitHub CI run `27515390795`: lint, security, test 3.11, test 3.12, test 3.13 all passed
