### PR TITLE
feat(memory): add optional subtype filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,12 +146,14 @@ Synapto is designed to be the primary memory sink for MCP-compatible agents. Age
 
 | User signal | Tool action | Recommended type/layer |
 |-------------|-------------|------------------------|
-| "always X", "never Y", "from now on" | Store as a rule | `feedback` / `core` |
-| "don't do X", "that's wrong" | Store as a correction | `feedback` / `core` |
-| "we use X for Y", "our architecture is..." | Store as project context | `project` / `stable` |
-| "this sprint", "current PR", "release plan" | Store as active work | `project` / `working` |
-| "tracked in Linear", "dashboard is..." | Store as external reference | `reference` / `stable` |
-| "I work on...", "my preference is..." | Store as user context | `user` / `stable` |
+| "always X", "never Y", "from now on" | Store as a rule | `feedback` / `core`, subtype `workflow` |
+| "don't do X", "that's wrong" | Store as a correction | `feedback` / `core`, subtype `communication` or `workflow` |
+| "we use X for Y", "our architecture is..." | Store as project context | `project` / `stable`, subtype `stable` |
+| "this sprint", "current PR", "release plan" | Store as active work | `project` / `working`, subtype `working` |
+| "tracked in Linear", "dashboard is..." | Store as external reference | `reference` / `stable`, subtype `external_system` |
+| "I work on...", "my preference is..." | Store as user context | `user` / `stable`, subtype `preference` |
+
+`subtype` is optional and free-form. Recommended values include `code_style`, `workflow`, `tooling`, `testing`, `security`, `communication`, `external_system`, `documentation`, `role`, `preference`, `skill`, and `constraint`.
 
 ## MCP Tools
 
@@ -181,6 +183,7 @@ get actionable errors instead of raw Postgres exceptions.
 | `content` | Text; no Synapto length limit |
 | `summary` | Max 255 characters |
 | `memory_type` | Max 20 characters |
+| `subtype` | Optional free-form subcategory, max 50 characters |
 | `depth_layer` | Max 20 characters |
 | `tenant` | Max 100 characters |
 | `get_memories.memory_ids` | Max 20 IDs per call |

--- a/migrations/004_add_memory_subtype.sql
+++ b/migrations/004_add_memory_subtype.sql
@@ -1,0 +1,12 @@
+-- migrate:up
+
+ALTER TABLE memories ADD COLUMN IF NOT EXISTS subtype VARCHAR(50);
+
+CREATE INDEX IF NOT EXISTS idx_memories_tenant_subtype
+    ON memories (tenant, subtype)
+    WHERE deleted_at IS NULL AND subtype IS NOT NULL;
+
+-- migrate:down
+
+DROP INDEX IF EXISTS idx_memories_tenant_subtype;
+ALTER TABLE memories DROP COLUMN IF EXISTS subtype;

--- a/src/synapto/cli.py
+++ b/src/synapto/cli.py
@@ -504,7 +504,7 @@ def export_cmd(tenant: str | None, output: str) -> None:
         t = tenant or config.default_tenant
         rows = await client.execute(
             """
-            SELECT id, content, summary, type, tenant, depth_layer, metadata, created_at, accessed_at
+            SELECT id, content, summary, type, subtype, tenant, depth_layer, metadata, created_at, accessed_at
             FROM memories WHERE deleted_at IS NULL AND tenant = %s ORDER BY created_at;
             """,
             (t,),
@@ -571,8 +571,9 @@ def import_cmd(file_path: str, tenant: str | None, fmt: str) -> None:
             emb = await provider.embed_one(content)
             await client.execute(
                 """
-                INSERT INTO memories (content, summary, embedding, embedding_dim, type, tenant, depth_layer, metadata)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s);
+                INSERT INTO memories
+                    (content, summary, embedding, embedding_dim, type, subtype, tenant, depth_layer, metadata)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s);
                 """,
                 (
                     content,
@@ -580,6 +581,7 @@ def import_cmd(file_path: str, tenant: str | None, fmt: str) -> None:
                     emb,
                     provider.dimension,
                     item.get("type", "general"),
+                    item.get("subtype"),
                     t,
                     item.get("depth_layer", "stable"),
                     Jsonb(item.get("metadata", {})),
@@ -818,8 +820,8 @@ def migrate_memories(dry_run: bool, home: str | None) -> None:
                                 """
                                 INSERT INTO memories
                                     (content, summary, embedding, embedding_dim,
-                                     type, tenant, depth_layer, metadata)
-                                VALUES (%s, %s, %s, %s, %s, %s, %s, %s);
+                                     type, subtype, tenant, depth_layer, metadata)
+                                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s);
                                 """,
                                 (
                                     mem.content,
@@ -827,6 +829,7 @@ def migrate_memories(dry_run: bool, home: str | None) -> None:
                                     embedding,
                                     provider.dimension,
                                     mem.memory_type,
+                                    None,
                                     config.default_tenant,
                                     mem.depth_layer,
                                     Jsonb(meta),

--- a/src/synapto/repositories/memories.py
+++ b/src/synapto/repositories/memories.py
@@ -18,8 +18,11 @@ from synapto.db.postgres import PostgresClient
 # ---------------------------------------------------------------------------
 
 _INSERT = """
-    INSERT INTO memories (content, summary, embedding, embedding_dim, type, tenant, depth_layer, metadata)
-    VALUES (%(content)s, %(summary)s, %(emb)s, %(dim)s, %(type)s, %(tenant)s, %(depth)s, %(meta)s)
+    INSERT INTO memories (content, summary, embedding, embedding_dim, type, subtype, tenant, depth_layer, metadata)
+    VALUES (
+        %(content)s, %(summary)s, %(emb)s, %(dim)s, %(type)s, %(subtype)s,
+        %(tenant)s, %(depth)s, %(meta)s
+    )
     RETURNING id;
 """
 
@@ -29,6 +32,7 @@ _GET_BY_ID = """
         content,
         summary,
         type,
+        subtype,
         tenant,
         depth_layer,
         metadata,
@@ -47,6 +51,7 @@ _GET_BY_IDS = """
         content,
         summary,
         type,
+        subtype,
         tenant,
         depth_layer,
         metadata,
@@ -79,6 +84,7 @@ _UPDATE_MEMORY = """
         content,
         summary,
         type,
+        subtype,
         tenant,
         depth_layer,
         metadata,
@@ -138,7 +144,7 @@ _SELECT_HRR_VECTORS = """
 """
 
 _SELECT_WITH_HRR = """
-    SELECT id, content, type, tenant, depth_layer, trust_score, hrr_vector
+    SELECT id, content, type, subtype, tenant, depth_layer, trust_score, hrr_vector
     FROM memories
     WHERE {where_clause}
     LIMIT %s;
@@ -187,6 +193,7 @@ class MemoryRepository:
         memory_type: str,
         tenant: str,
         depth_layer: str,
+        subtype: str | None = None,
         summary: str | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> UUID:
@@ -198,6 +205,7 @@ class MemoryRepository:
                 "emb": embedding,
                 "dim": embedding_dim,
                 "type": memory_type,
+                "subtype": subtype,
                 "tenant": tenant,
                 "depth": depth_layer,
                 "meta": Jsonb(metadata or {}),

--- a/src/synapto/search/hybrid.py
+++ b/src/synapto/search/hybrid.py
@@ -36,7 +36,7 @@ WITH semantic_search AS (
     FROM memories
     WHERE deleted_at IS NULL
       AND tenant = %(tenant)s
-      {{depth_filter}}
+      {{filters}}
     ORDER BY embedding::vector({dim}) <=> %(embedding)s::vector({dim})
     LIMIT 20
 ),
@@ -50,7 +50,7 @@ keyword_search AS (
     WHERE deleted_at IS NULL
       AND tenant = %(tenant)s
       AND tsv @@ plainto_tsquery('english', %(query)s)
-      {{depth_filter}}
+      {{filters}}
     ORDER BY ts_rank_cd(tsv, plainto_tsquery('english', %(query)s)) DESC
     LIMIT 20
 )
@@ -59,6 +59,7 @@ SELECT
     m.content,
     m.summary,
     m.type,
+    m.subtype,
     m.tenant,
     m.depth_layer,
     m.decay_score,
@@ -96,6 +97,7 @@ class SearchResult:
     content: str
     summary: str | None
     type: str
+    subtype: str | None
     tenant: str
     depth_layer: str
     decay_score: float
@@ -133,6 +135,7 @@ async def hybrid_search(
     query: str,
     tenant: str = "default",
     depth_layer: str | None = None,
+    subtype: str | None = None,
     limit: int = 10,
     rrf_k: int = 60,
 ) -> list[SearchResult]:
@@ -140,7 +143,7 @@ async def hybrid_search(
     embedding = await provider.embed_one(query)
     dim = provider.dimension
 
-    depth_filter = ""
+    filters = []
     params: dict[str, Any] = {
         "embedding": embedding,
         "query": query,
@@ -149,10 +152,13 @@ async def hybrid_search(
         "limit": limit * 2,  # fetch extra for HRR reranking
     }
     if depth_layer:
-        depth_filter = "AND depth_layer = %(depth_layer)s"
+        filters.append("AND depth_layer = %(depth_layer)s")
         params["depth_layer"] = depth_layer
+    if subtype:
+        filters.append("AND subtype = %(subtype)s")
+        params["subtype"] = subtype
 
-    sql = RRF_QUERY_TEMPLATE.format(dim=dim).format(depth_filter=depth_filter)
+    sql = RRF_QUERY_TEMPLATE.format(dim=dim).format(filters="\n      ".join(filters))
 
     rows = await client.execute(sql, params)
 
@@ -176,6 +182,7 @@ async def hybrid_search(
             content=row["content"],
             summary=row["summary"],
             type=row["type"],
+            subtype=row.get("subtype"),
             tenant=row["tenant"],
             depth_layer=row["depth_layer"],
             decay_score=row["decay_score"],
@@ -192,13 +199,13 @@ async def hybrid_search(
 
 VECTOR_ONLY_TEMPLATE = """
 SELECT
-    id, content, summary, type, tenant, depth_layer, decay_score, trust_score, metadata,
+    id, content, summary, type, subtype, tenant, depth_layer, decay_score, trust_score, metadata,
     access_count, created_at, accessed_at,
     1 - (embedding::vector({dim}) <=> %(embedding)s::vector({dim})) AS similarity
 FROM memories
 WHERE deleted_at IS NULL
   AND tenant = %(tenant)s
-  {{depth_filter}}
+  {{filters}}
 ORDER BY embedding::vector({dim}) <=> %(embedding)s::vector({dim})
 LIMIT %(limit)s;
 """
@@ -210,23 +217,27 @@ async def vector_search(
     query: str,
     tenant: str = "default",
     depth_layer: str | None = None,
+    subtype: str | None = None,
     limit: int = 10,
 ) -> list[SearchResult]:
     """Pure vector similarity search (no keyword component)."""
     embedding = await provider.embed_one(query)
     dim = provider.dimension
 
-    depth_filter = ""
+    filters = []
     params: dict[str, Any] = {
         "embedding": embedding,
         "tenant": tenant,
         "limit": limit,
     }
     if depth_layer:
-        depth_filter = "AND depth_layer = %(depth_layer)s"
+        filters.append("AND depth_layer = %(depth_layer)s")
         params["depth_layer"] = depth_layer
+    if subtype:
+        filters.append("AND subtype = %(subtype)s")
+        params["subtype"] = subtype
 
-    sql = VECTOR_ONLY_TEMPLATE.format(dim=dim).format(depth_filter=depth_filter)
+    sql = VECTOR_ONLY_TEMPLATE.format(dim=dim).format(filters="\n  ".join(filters))
 
     rows = await client.execute(sql, params)
 
@@ -236,6 +247,7 @@ async def vector_search(
             content=row["content"],
             summary=row["summary"],
             type=row["type"],
+            subtype=row.get("subtype"),
             tenant=row["tenant"],
             depth_layer=row["depth_layer"],
             decay_score=row["decay_score"],

--- a/src/synapto/search/hybrid.py
+++ b/src/synapto/search/hybrid.py
@@ -129,6 +129,28 @@ def _compute_hrr_boost(query: str, hrr_vector: bytes | None, hrr_weight: float =
         return 0.0
 
 
+def _build_memory_filters(
+    *,
+    depth_layer: str | None = None,
+    subtype: str | None = None,
+    indent: str,
+) -> tuple[str, dict[str, str]]:
+    """Build shared optional memory filters.
+
+    Complexity: O(1) time and space because the supported filter set is fixed.
+    User values stay in params so SQL rendering remains injection-safe.
+    """
+    filters = []
+    params = {}
+    if depth_layer:
+        filters.append("AND depth_layer = %(depth_layer)s")
+        params["depth_layer"] = depth_layer
+    if subtype:
+        filters.append("AND subtype = %(subtype)s")
+        params["subtype"] = subtype
+    return f"\n{indent}".join(filters), params
+
+
 async def hybrid_search(
     client: PostgresClient,
     provider: EmbeddingProvider,
@@ -143,7 +165,6 @@ async def hybrid_search(
     embedding = await provider.embed_one(query)
     dim = provider.dimension
 
-    filters = []
     params: dict[str, Any] = {
         "embedding": embedding,
         "query": query,
@@ -151,14 +172,14 @@ async def hybrid_search(
         "rrf_k": rrf_k,
         "limit": limit * 2,  # fetch extra for HRR reranking
     }
-    if depth_layer:
-        filters.append("AND depth_layer = %(depth_layer)s")
-        params["depth_layer"] = depth_layer
-    if subtype:
-        filters.append("AND subtype = %(subtype)s")
-        params["subtype"] = subtype
+    filter_sql, filter_params = _build_memory_filters(
+        depth_layer=depth_layer,
+        subtype=subtype,
+        indent="      ",
+    )
+    params.update(filter_params)
 
-    sql = RRF_QUERY_TEMPLATE.format(dim=dim).format(filters="\n      ".join(filters))
+    sql = RRF_QUERY_TEMPLATE.format(dim=dim).format(filters=filter_sql)
 
     rows = await client.execute(sql, params)
 
@@ -224,20 +245,19 @@ async def vector_search(
     embedding = await provider.embed_one(query)
     dim = provider.dimension
 
-    filters = []
     params: dict[str, Any] = {
         "embedding": embedding,
         "tenant": tenant,
         "limit": limit,
     }
-    if depth_layer:
-        filters.append("AND depth_layer = %(depth_layer)s")
-        params["depth_layer"] = depth_layer
-    if subtype:
-        filters.append("AND subtype = %(subtype)s")
-        params["subtype"] = subtype
+    filter_sql, filter_params = _build_memory_filters(
+        depth_layer=depth_layer,
+        subtype=subtype,
+        indent="  ",
+    )
+    params.update(filter_params)
 
-    sql = VECTOR_ONLY_TEMPLATE.format(dim=dim).format(filters="\n  ".join(filters))
+    sql = VECTOR_ONLY_TEMPLATE.format(dim=dim).format(filters=filter_sql)
 
     rows = await client.execute(sql, params)
 

--- a/src/synapto/server.py
+++ b/src/synapto/server.py
@@ -126,6 +126,7 @@ DEFAULT_RECALL_PREVIEW_CHARS = 200
 MAX_BULK_MEMORY_IDS = 20
 MAX_SUMMARY_CHARS = 255
 MAX_MEMORY_TYPE_CHARS = 20
+MAX_SUBTYPE_CHARS = 50
 MAX_TENANT_CHARS = 100
 MAX_DEPTH_LAYER_CHARS = 20
 RECALL_CONTENT_ELIDED = "[content elided - fetch full via get_memory(id)]"
@@ -163,11 +164,13 @@ def _validate_max_chars(field: str, value: str | None, max_chars: int, *, guidan
 def _validate_memory_fields(
     *,
     memory_type: str | None = None,
+    subtype: str | None = None,
     tenant: str | None = None,
     depth_layer: str | None = None,
     summary: str | None = None,
 ) -> None:
     _validate_max_chars("memory_type", memory_type, MAX_MEMORY_TYPE_CHARS)
+    _validate_max_chars("subtype", subtype, MAX_SUBTYPE_CHARS)
     _validate_max_chars("tenant", tenant, MAX_TENANT_CHARS)
     _validate_max_chars("depth_layer", depth_layer, MAX_DEPTH_LAYER_CHARS)
     _validate_max_chars(
@@ -197,6 +200,8 @@ def _format_memory(
         f"created_at: {_format_timestamp(row.get('created_at'))}",
         f"accessed_at: {_format_timestamp(row.get('accessed_at'))}",
     ]
+    if row.get("subtype"):
+        lines.insert(3, f"subtype: {row['subtype']}")
     if row.get("summary"):
         lines.append(f"summary: {row['summary']}")
     lines.append(f"metadata: {_format_json(row.get('metadata'))}")
@@ -351,6 +356,7 @@ def handoff_inbox_template(
 async def remember(
     content: str,
     memory_type: str = "general",
+    subtype: str | None = None,
     tenant: str | None = None,
     depth_layer: str = "working",
     summary: str | None = None,
@@ -376,6 +382,14 @@ async def remember(
       or personal preferences.
     - general: useful context that does not fit another category.
 
+    Optional subtype is free-form and not enum-validated. Use it to improve
+    recall precision within a memory_type. Recommended subtypes:
+    - feedback: code_style, workflow, tooling, testing, security, communication.
+    - reference: external_system, internal_dashboard, documentation, team,
+      infra_config.
+    - project: working, stable, archived.
+    - user: role, preference, skill, constraint.
+
     Recommended depth_layer choices:
     - core: rules that should not expire, such as "always" or "never" feedback.
     - stable: context expected to last months, such as architecture decisions.
@@ -385,13 +399,20 @@ async def remember(
     Args:
         content: memory content to store (text; no Synapto length limit)
         memory_type: category (general, user, feedback, project, reference; max 20 chars)
+        subtype: optional free-form subcategory (recommended values documented; max 50 chars)
         tenant: project/tenant scope (defaults to config default; max 100 chars)
         depth_layer: core, stable, working, or ephemeral (max 20 chars)
         summary: optional short summary (max 255 chars)
         metadata: optional JSON metadata
         extract_entities: auto-extract and link entities from content
     """
-    _validate_memory_fields(memory_type=memory_type, tenant=tenant, depth_layer=depth_layer, summary=summary)
+    _validate_memory_fields(
+        memory_type=memory_type,
+        subtype=subtype,
+        tenant=tenant,
+        depth_layer=depth_layer,
+        summary=summary,
+    )
 
     pg = _get_pg()
     provider = _get_provider()
@@ -405,6 +426,7 @@ async def remember(
         embedding=embedding,
         embedding_dim=provider.dimension,
         memory_type=memory_type,
+        subtype=subtype,
         tenant=t,
         depth_layer=depth_layer,
         summary=summary,
@@ -427,7 +449,10 @@ async def remember(
         logger.warning("hrr vector computation failed for %s: %s", memory_id, e)
 
     cache = _get_cache()
-    await cache.cache_memory(memory_id, {"content": content, "type": memory_type, "tenant": t})
+    await cache.cache_memory(
+        memory_id,
+        {"content": content, "type": memory_type, "subtype": subtype, "tenant": t},
+    )
 
     entity_count = len(entity_names)
     return f"stored memory {memory_id} ({depth_layer}, {entity_count} entities linked)"
@@ -530,6 +555,7 @@ async def recall(
     query: str,
     tenant: str | None = None,
     depth_layer: str | None = None,
+    subtype: str | None = None,
     limit: int = 10,
     preview_chars: int = DEFAULT_RECALL_PREVIEW_CHARS,
 ) -> str:
@@ -541,24 +567,34 @@ async def recall(
     "what do we know about" style questions. Recall proactively rather than
     waiting for the user to ask.
 
-    Use tenant to scope project-specific memory and depth_layer to narrow the
-    result set when you need only core rules, stable architecture, working task
-    context, or ephemeral debugging notes. Follow up with get_memory when a
-    recalled result needs full content, metadata, or linked entities.
+    Use tenant to scope project-specific memory, depth_layer to narrow by decay
+    semantics, and subtype to narrow within a memory_type, such as workflow or
+    code_style feedback. Follow up with get_memory when a recalled result needs
+    full content, metadata, or linked entities.
 
     Args:
         query: natural language search query
         tenant: filter to a specific project/tenant
         depth_layer: filter to a specific depth layer (core, stable, working, ephemeral)
+        subtype: optional memory subcategory filter (for example code_style or workflow)
         limit: max results to return
         preview_chars: max content characters per result (0-1000)
     """
     pg = _get_pg()
     provider = _get_provider()
     t = tenant or _config.default_tenant
+    _validate_memory_fields(subtype=subtype)
     preview_chars = max(0, min(preview_chars, MAX_RECALL_PREVIEW_CHARS))
 
-    results = await hybrid_search(pg, provider, query, tenant=t, depth_layer=depth_layer, limit=limit)
+    results = await hybrid_search(
+        pg,
+        provider,
+        query,
+        tenant=t,
+        depth_layer=depth_layer,
+        subtype=subtype,
+        limit=limit,
+    )
 
     if not results:
         return _wrap_system_reminder(load_prompt("recall_empty"))
@@ -571,8 +607,9 @@ async def recall(
             preview = r.content[:preview_chars]
             if len(r.content) > preview_chars:
                 preview += "..."
+        type_label = r.type if not getattr(r, "subtype", None) else f"{r.type}/{r.subtype}"
         memories.append(
-            f"[{r.depth_layer}] ({r.type}) score={r.rrf_score:.4f} "
+            f"[{r.depth_layer}] ({type_label}) score={r.rrf_score:.4f} "
             f"decay={r.decay_score:.2f} trust={r.trust_score:.2f} "
             f"tenant={r.tenant} created_at={_format_timestamp(r.created_at)}\n"
             f"  {preview}\n"

--- a/tests/unit/test_memory_retrieval_tools.py
+++ b/tests/unit/test_memory_retrieval_tools.py
@@ -39,12 +39,12 @@ async def _cleanup(pg):
     await pg.execute("DELETE FROM entities WHERE tenant = %s;", (TENANT,))
 
 
-async def _insert_memory(pg, provider, content: str, *, summary: str | None = None):
+async def _insert_memory(pg, provider, content: str, *, summary: str | None = None, subtype: str | None = None):
     emb = await provider.embed_one(content)
     row = await pg.execute_one(
         """
-        INSERT INTO memories (content, summary, embedding, embedding_dim, type, tenant, depth_layer, metadata)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s) RETURNING id;
+        INSERT INTO memories (content, summary, embedding, embedding_dim, type, subtype, tenant, depth_layer, metadata)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING id;
         """,
         (
             content,
@@ -52,6 +52,7 @@ async def _insert_memory(pg, provider, content: str, *, summary: str | None = No
             emb,
             provider.dimension,
             "reference",
+            subtype,
             TENANT,
             "stable",
             Jsonb({"source": "test"}),
@@ -63,7 +64,13 @@ async def _insert_memory(pg, provider, content: str, *, summary: str | None = No
 async def test_memory_repository_get_by_id_returns_full_record(pg, provider):
     await run_migrations(pg)
     await _cleanup(pg)
-    memory_id = await _insert_memory(pg, provider, "full content survives retrieval", summary="full")
+    memory_id = await _insert_memory(
+        pg,
+        provider,
+        "full content survives retrieval",
+        summary="full",
+        subtype="documentation",
+    )
 
     row = await MemoryRepository(pg).get_by_id(memory_id)
 
@@ -71,6 +78,7 @@ async def test_memory_repository_get_by_id_returns_full_record(pg, provider):
     assert row["id"] == memory_id
     assert row["content"] == "full content survives retrieval"
     assert row["summary"] == "full"
+    assert row["subtype"] == "documentation"
     assert row["metadata"] == {"source": "test"}
 
     await _cleanup(pg)
@@ -286,6 +294,7 @@ async def test_recall_preview_zero_uses_explicit_elision_marker(monkeypatch):
                 id="00000000-0000-0000-0000-000000000001",
                 content="hidden content",
                 type="reference",
+                subtype=None,
                 tenant=TENANT,
                 depth_layer="stable",
                 decay_score=1.0,
@@ -304,3 +313,20 @@ async def test_recall_preview_zero_uses_explicit_elision_marker(monkeypatch):
 
     assert server.RECALL_CONTENT_ELIDED in output
     assert "hidden content" not in output
+
+
+async def test_recall_passes_subtype_filter_to_hybrid_search(monkeypatch):
+    captured = {}
+
+    async def fake_hybrid_search(*args, **kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(server, "_pg", object())
+    monkeypatch.setattr(server, "_provider", object())
+    monkeypatch.setattr(server, "_config", SimpleNamespace(default_tenant=TENANT))
+    monkeypatch.setattr(server, "hybrid_search", fake_hybrid_search)
+
+    await server.recall("coding standards", subtype="code_style")
+
+    assert captured["subtype"] == "code_style"

--- a/tests/unit/test_migrations.py
+++ b/tests/unit/test_migrations.py
@@ -152,7 +152,7 @@ class TestMigrationRunner:
         version = await get_schema_version(pg)
         # The synapto_migrations tracking table is shared with the project's real
         # migrations, so version reflects the highest applied number across both
-        # the project (currently up to 003) and these temp migrations (002).
+        # the project (currently up to 004) and these temp migrations (002).
         # Assert at least the temp migrations landed rather than pinning an exact value.
         assert version is not None and version >= 2
 

--- a/tests/unit/test_search_and_graph.py
+++ b/tests/unit/test_search_and_graph.py
@@ -41,15 +41,15 @@ async def pg(pg):
     await pg.execute("DELETE FROM entities WHERE tenant = %s;", (TENANT,))
 
 
-async def _insert_memory(pg, provider, content, depth_layer="working", mem_type="general"):
+async def _insert_memory(pg, provider, content, depth_layer="working", mem_type="general", subtype=None):
     """Helper to insert a memory with embedding."""
     emb = await provider.embed_one(content)
     row = await pg.execute_one(
         """
-        INSERT INTO memories (content, embedding, embedding_dim, type, tenant, depth_layer)
-        VALUES (%s, %s, %s, %s, %s, %s) RETURNING id;
+        INSERT INTO memories (content, embedding, embedding_dim, type, subtype, tenant, depth_layer)
+        VALUES (%s, %s, %s, %s, %s, %s, %s) RETURNING id;
         """,
-        (content, emb, provider.dimension, mem_type, TENANT, depth_layer),
+        (content, emb, provider.dimension, mem_type, subtype, TENANT, depth_layer),
     )
     return row["id"]
 
@@ -80,6 +80,28 @@ class TestHybridSearch:
         results = await hybrid_search(pg, provider, "architecture", tenant=TENANT, depth_layer="core")
         assert all(r.depth_layer == "core" for r in results)
 
+    async def test_subtype_filter(self, pg, provider):
+        await ensure_hnsw_index(pg, provider.dimension)
+        await _insert_memory(
+            pg,
+            provider,
+            "always run ruff before commit",
+            mem_type="feedback",
+            subtype="workflow",
+        )
+        await _insert_memory(
+            pg,
+            provider,
+            "prefer small functions",
+            mem_type="feedback",
+            subtype="code_style",
+        )
+
+        results = await hybrid_search(pg, provider, "always run ruff", tenant=TENANT, subtype="workflow")
+
+        assert results
+        assert all(r.subtype == "workflow" for r in results)
+
 
 class TestHybridSearchParameterization:
     """Tests that depth_layer filtering uses parameterized queries (not f-string injection)."""
@@ -93,6 +115,21 @@ class TestHybridSearchParameterization:
         results = await hybrid_search(
             pg, provider, "should not appear", tenant=TENANT, depth_layer="working' OR '1'='1"
         )
+        assert len(results) == 0
+
+    async def test_subtype_with_special_characters(self, pg, provider):
+        """Ensure subtype with SQL injection payload doesn't break or leak data."""
+        await ensure_hnsw_index(pg, provider.dimension)
+        await _insert_memory(pg, provider, "workflow note should not leak", subtype="workflow")
+
+        results = await hybrid_search(
+            pg,
+            provider,
+            "workflow note",
+            tenant=TENANT,
+            subtype="workflow' OR '1'='1",
+        )
+
         assert len(results) == 0
 
     async def test_depth_layer_none_returns_all_layers(self, pg, provider):
@@ -114,6 +151,22 @@ class TestHybridSearchParameterization:
         # injection attempt should return nothing
         results = await vector_search(
             pg, provider, "debug session", tenant=TENANT, depth_layer="ephemeral' OR '1'='1"
+        )
+        assert len(results) == 0
+
+    async def test_vector_search_subtype_parameterized(self, pg, provider):
+        await ensure_hnsw_index(pg, provider.dimension)
+        await _insert_memory(pg, provider, "workflow debug session", subtype="workflow")
+
+        results = await vector_search(pg, provider, "debug session", tenant=TENANT, subtype="workflow")
+        assert all(r.subtype == "workflow" for r in results)
+
+        results = await vector_search(
+            pg,
+            provider,
+            "debug session",
+            tenant=TENANT,
+            subtype="workflow' OR '1'='1",
         )
         assert len(results) == 0
 

--- a/tests/unit/test_tool_metadata.py
+++ b/tests/unit/test_tool_metadata.py
@@ -50,6 +50,7 @@ async def test_memory_tool_descriptions_document_hard_limits():
 
     assert "summary: optional short summary (max 255 chars)" in remember.description
     assert "memory_type" in remember.description and "max 20 chars" in remember.description
+    assert "subtype" in remember.description and "max 50 chars" in remember.description
     assert "tenant" in remember.description and "max 100 chars" in remember.description
     assert "depth_layer" in remember.description and "max 20 chars" in remember.description
     assert "summary: optional replacement summary (max 255 chars)" in update_memory.description
@@ -65,7 +66,11 @@ async def test_remember_description_guides_automatic_memory_capture():
         "project context",
         "Store the memory in Synapto instead of writing flat files",
         "Recommended memory_type choices",
+        "Recommended subtypes",
         "Recommended depth_layer choices",
+        "code_style",
+        "workflow",
+        "external_system",
         "feedback",
         "project",
         "reference",
@@ -87,6 +92,7 @@ async def test_recall_description_guides_proactive_context_loading():
         "preferences",
         "Recall proactively",
         "Use tenant to scope project-specific memory",
+        "subtype to narrow within a memory_type",
         "Follow up with get_memory",
     ):
         assert phrase in recall.description


### PR DESCRIPTION
## Summary
- add nullable `memories.subtype` plus tenant/subtype index via migration 004
- let `remember(..., subtype=...)` store optional free-form subcategories
- let `recall(..., subtype=...)`, `hybrid_search`, and `vector_search` filter by subtype with parameterized SQL
- share subtype/depth filter construction through a single helper to avoid duplicated search logic
- include subtype in retrieval formatting, export/import JSON, README guidance, and MCP tool descriptions
- add tests for persistence, recall forwarding, subtype search filters, injection safety, and tool metadata

## Release plan
- Target: v0.5.0 source-of-truth / governed context layer
- Closes #51

## Review follow-up
- Resolved Clean Code finding from review by extracting duplicate memory filter construction into `_build_memory_filters(...)`.
- Performance note: subtype filtering remains parameterized and O(1) to build in Python; DB-side behavior depends on planner/index selectivity and should be validated with `EXPLAIN ANALYZE` once representative memory volume exists.

## Validation
- `git diff --check`
- `uv run pytest tests/unit/test_migrations.py tests/unit/test_search_and_graph.py tests/unit/test_memory_retrieval_tools.py tests/unit/test_tool_metadata.py -q` (70 passed)
- `uv run pytest tests/unit/test_search_and_graph.py -q` (21 passed after review follow-up)
- `uv run pytest tests/unit -q` (242 passed after review follow-up)
- `uv run ruff check src/synapto/search/hybrid.py tests/unit/test_search_and_graph.py`
- `uv run ruff check src/ tests/`
- GitHub CI run `27515871845`: lint, security, test 3.11, test 3.12, test 3.13 all passed
