### PR TITLE
fix(mcp): improve stdio transport diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **MCP stdio transport friendliness for long-running agent sessions** by adding a lightweight `ping` health tool, allowing sentence-transformers device override via `SYNAPTO_EMBEDDING_DEVICE` / `[embeddings].device`, disabling sentence-transformers encode progress bars, and ensuring CLI/MCP embedding provider paths share the same model/device configuration.
+
 ## [0.5.0] - 2026-07-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Synapto is designed to be the primary memory sink for MCP-compatible agents. Age
 |------|-------------|
 | `remember` | Store a memory (entities and search vectors are created automatically) |
 | `recall` | Search memories by meaning |
+| `ping` | Check MCP transport health without touching PostgreSQL, Redis, or embeddings |
 | `get_memory` | Fetch the complete content and metadata for one recalled memory |
 | `get_memories` | Fetch complete content for multiple recalled memories |
 | `update_memory` | Replace, append, or patch fields on an existing memory |
@@ -240,8 +241,9 @@ dsn = "postgresql://localhost/synapto"
 url = "redis://localhost:6379/0"
 
 [embeddings]
-provider = ""  # auto-select (sentence-transformers on CPU, openai if API key set)
+provider = ""  # auto-select (sentence-transformers locally, openai if API key set)
 model = ""
+device = ""  # optional sentence-transformers device override, e.g. "cpu"
 
 [defaults]
 tenant = "default"
@@ -251,7 +253,7 @@ ephemeral_max_age_hours = 24
 purge_after_days = 30
 ```
 
-All values can be overridden with environment variables: `SYNAPTO_PG_DSN`, `SYNAPTO_REDIS_URL`, `SYNAPTO_EMBEDDING_PROVIDER`, `SYNAPTO_DEFAULT_TENANT`.
+All values can be overridden with environment variables: `SYNAPTO_PG_DSN`, `SYNAPTO_REDIS_URL`, `SYNAPTO_EMBEDDING_PROVIDER`, `SYNAPTO_EMBEDDING_MODEL`, `SYNAPTO_EMBEDDING_DEVICE`, `SYNAPTO_DEFAULT_TENANT`.
 
 ## Using as a Python library
 

--- a/src/synapto/cli.py
+++ b/src/synapto/cli.py
@@ -209,7 +209,7 @@ def search(query: str, tenant: str | None, limit: int, depth: str | None) -> Non
     """Search memories from the command line."""
 
     async def _search():
-        from synapto.config import load_config
+        from synapto.config import embedding_provider_kwargs, load_config
         from synapto.db.migrations import ensure_hnsw_index
         from synapto.db.postgres import PostgresClient
         from synapto.embeddings.registry import get_provider
@@ -221,7 +221,7 @@ def search(query: str, tenant: str | None, limit: int, depth: str | None) -> Non
         client = PostgresClient(config.pg_dsn)
         await client.connect()
 
-        provider = get_provider(config.embedding_provider)
+        provider = get_provider(config.embedding_provider, **embedding_provider_kwargs(config))
         await ensure_hnsw_index(client, provider.dimension)
 
         results = await hybrid_search(
@@ -359,9 +359,10 @@ def doctor() -> None:
 
     # 5. embedding model
     try:
+        from synapto.config import embedding_provider_kwargs
         from synapto.embeddings.registry import get_provider
 
-        provider = get_provider(config.embedding_provider)
+        provider = get_provider(config.embedding_provider, **embedding_provider_kwargs(config))
         click.echo(_green(f"embedding model: {provider.name} (dim={provider.dimension})"))
     except Exception as e:
         click.echo(_fail(f"embedding model: {e}", "check embedding provider config"))
@@ -539,7 +540,7 @@ def import_cmd(file_path: str, tenant: str | None, fmt: str) -> None:
     async def _import():
         from psycopg.types.json import Jsonb
 
-        from synapto.config import load_config
+        from synapto.config import embedding_provider_kwargs, load_config
         from synapto.db.migrations import ensure_hnsw_index, run_migrations
         from synapto.db.postgres import PostgresClient
         from synapto.embeddings.registry import get_provider
@@ -551,7 +552,7 @@ def import_cmd(file_path: str, tenant: str | None, fmt: str) -> None:
         await client.connect()
         await run_migrations(client)
 
-        provider = get_provider(config.embedding_provider)
+        provider = get_provider(config.embedding_provider, **embedding_provider_kwargs(config))
         await ensure_hnsw_index(client, provider.dimension)
 
         with open(file_path) as f:
@@ -772,7 +773,7 @@ def migrate_memories(dry_run: bool, home: str | None) -> None:
 
         from psycopg.types.json import Jsonb
 
-        from synapto.config import load_config
+        from synapto.config import embedding_provider_kwargs, load_config
         from synapto.db.migrations import ensure_hnsw_index, run_migrations
         from synapto.db.postgres import PostgresClient
         from synapto.embeddings.registry import get_provider
@@ -783,7 +784,7 @@ def migrate_memories(dry_run: bool, home: str | None) -> None:
         await client.connect()
         await run_migrations(client)
 
-        provider = get_provider(config.embedding_provider)
+        provider = get_provider(config.embedding_provider, **embedding_provider_kwargs(config))
         await ensure_hnsw_index(client, provider.dimension)
 
         mem_repo = MemoryRepository(client)

--- a/src/synapto/config.py
+++ b/src/synapto/config.py
@@ -21,6 +21,7 @@ class SynaptoConfig:
     # embeddings
     embedding_provider: str | None = None  # None = auto-select
     embedding_model: str | None = None
+    embedding_device: str | None = None
 
     # defaults
     default_tenant: str = "default"
@@ -54,6 +55,7 @@ def load_config(config_path: Path | None = None) -> SynaptoConfig:
             emb = data.get("embeddings", {})
             config.embedding_provider = emb.get("provider", config.embedding_provider)
             config.embedding_model = emb.get("model", config.embedding_model)
+            config.embedding_device = emb.get("device", config.embedding_device)
 
             defaults = data.get("defaults", {})
             config.default_tenant = defaults.get("tenant", config.default_tenant)
@@ -85,6 +87,7 @@ def load_config(config_path: Path | None = None) -> SynaptoConfig:
         "SYNAPTO_REDIS_URL": "redis_url",
         "SYNAPTO_EMBEDDING_PROVIDER": "embedding_provider",
         "SYNAPTO_EMBEDDING_MODEL": "embedding_model",
+        "SYNAPTO_EMBEDDING_DEVICE": "embedding_device",
         "SYNAPTO_DEFAULT_TENANT": "default_tenant",
     }
     for env_var, attr in env_map.items():
@@ -93,6 +96,16 @@ def load_config(config_path: Path | None = None) -> SynaptoConfig:
             setattr(config, attr, val)
 
     return config
+
+
+def embedding_provider_kwargs(config: SynaptoConfig) -> dict[str, str]:
+    """Return keyword arguments shared by all embedding provider call sites."""
+    kwargs = {}
+    if config.embedding_model:
+        kwargs["model_name"] = config.embedding_model
+    if config.embedding_device:
+        kwargs["device"] = config.embedding_device
+    return kwargs
 
 
 def save_default_config() -> Path:
@@ -110,6 +123,7 @@ def save_default_config() -> Path:
         "embeddings": {
             "provider": "",
             "model": "",
+            "device": "",
         },
         "defaults": {"tenant": "default"},
         "decay": {

--- a/src/synapto/embeddings/registry.py
+++ b/src/synapto/embeddings/registry.py
@@ -16,6 +16,14 @@ def register(name: str, cls: type[EmbeddingProvider]) -> None:
     _PROVIDERS[name] = cls
 
 
+def _openai_kwargs(kwargs: dict) -> dict:
+    """Translate generic embedding config kwargs to the OpenAI provider shape."""
+    provider_kwargs = {k: v for k, v in kwargs.items() if k != "device"}
+    if "model_name" in provider_kwargs and "model" not in provider_kwargs:
+        provider_kwargs["model"] = provider_kwargs.pop("model_name")
+    return provider_kwargs
+
+
 def get_provider(name: str | None = None, **kwargs) -> EmbeddingProvider:
     """Get an embedding provider by name, or auto-select the best available.
 
@@ -29,7 +37,7 @@ def get_provider(name: str | None = None, **kwargs) -> EmbeddingProvider:
 
         if name.startswith("openai"):
             from synapto.embeddings.openai_provider import OpenAIProvider
-            return OpenAIProvider(**kwargs)
+            return OpenAIProvider(**_openai_kwargs(kwargs))
 
         if name.startswith("sentence-transformer"):
             from synapto.embeddings.sentence_transformer import SentenceTransformerProvider
@@ -41,7 +49,7 @@ def get_provider(name: str | None = None, **kwargs) -> EmbeddingProvider:
     if os.environ.get("OPENAI_API_KEY"):
         try:
             from synapto.embeddings.openai_provider import OpenAIProvider
-            provider = OpenAIProvider(**kwargs)
+            provider = OpenAIProvider(**_openai_kwargs(kwargs))
             logger.info("auto-selected provider: %s", provider.name)
             return provider
         except (ImportError, ValueError):

--- a/src/synapto/embeddings/sentence_transformer.py
+++ b/src/synapto/embeddings/sentence_transformer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from functools import lru_cache
 
 from synapto.embeddings.base import EmbeddingProvider
@@ -14,12 +15,14 @@ DEFAULT_MODEL = "multi-qa-MiniLM-L6-cos-v1"
 DEFAULT_DIM = 384
 
 
-@lru_cache(maxsize=1)
-def _load_model(model_name: str):
+@lru_cache(maxsize=4)
+def _load_model(model_name: str, device: str | None):
     """Load the sentence-transformers model (cached singleton)."""
     from sentence_transformers import SentenceTransformer
 
-    logger.info("loading sentence-transformers model: %s", model_name)
+    logger.info("loading sentence-transformers model: %s (device=%s)", model_name, device or "auto")
+    if device:
+        return SentenceTransformer(model_name, device=device)
     return SentenceTransformer(model_name)
 
 
@@ -29,14 +32,19 @@ class SentenceTransformerProvider(EmbeddingProvider):
     Runs on CPU, no API key required. Default model: multi-qa-MiniLM-L6-cos-v1 (384 dim).
     """
 
-    def __init__(self, model_name: str = DEFAULT_MODEL) -> None:
+    def __init__(self, model_name: str = DEFAULT_MODEL, device: str | None = None) -> None:
         self._model_name = model_name
+        self._device = device or os.environ.get("SYNAPTO_EMBEDDING_DEVICE") or None
         self._dim: int | None = None
+
+    @property
+    def device(self) -> str | None:
+        return self._device
 
     @property
     def dimension(self) -> int:
         if self._dim is None:
-            model = _load_model(self._model_name)
+            model = _load_model(self._model_name, self._device)
             self._dim = model.get_embedding_dimension()
         return self._dim
 
@@ -45,9 +53,14 @@ class SentenceTransformerProvider(EmbeddingProvider):
         return f"sentence-transformers/{self._model_name}"
 
     async def embed(self, texts: list[str]) -> list[list[float]]:
-        model = _load_model(self._model_name)
+        model = _load_model(self._model_name, self._device)
         loop = asyncio.get_running_loop()
         embeddings = await loop.run_in_executor(
-            None, lambda: model.encode(texts, normalize_embeddings=True)
+            None,
+            lambda: model.encode(
+                texts,
+                normalize_embeddings=True,
+                show_progress_bar=False,
+            ),
         )
         return [vec.tolist() for vec in embeddings]

--- a/src/synapto/prompts/server_instructions.md
+++ b/src/synapto/prompts/server_instructions.md
@@ -1,6 +1,13 @@
 Synapto is the user's persistent memory system. Prefer it over flat files
 (MEMORY.md, CLAUDE.md notes, etc.) for storing new memories.
 
+Transport diagnostics:
+- Call `ping` first when checking MCP transport health. It only proves the MCP
+  connection is alive and does not touch PostgreSQL, Redis, or embeddings.
+- If tools fail with `Transport closed`, treat it as a closed MCP client
+  transport and ask the user to restart/reconnect the MCP client instead of
+  writing fallback flat-file memories.
+
 When to call `recall`:
 - At the start of any non-trivial task, to load relevant context.
 - When the user references past decisions, history, or preferences

--- a/src/synapto/server.py
+++ b/src/synapto/server.py
@@ -12,7 +12,7 @@ from uuid import UUID
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 
-from synapto.config import load_config
+from synapto.config import embedding_provider_kwargs, load_config
 from synapto.coordination import DEFAULT_HANDOFF_LIMIT, render_agent_handoff_prompt, render_handoff_inbox_prompt
 from synapto.db.migrations import ensure_hnsw_index, run_migrations
 from synapto.db.postgres import PostgresClient
@@ -90,10 +90,7 @@ async def _lifespan(server):
     _cache = RedisCache(_config.redis_url)
     await _cache.connect()
 
-    kwargs = {}
-    if _config.embedding_model:
-        kwargs["model_name"] = _config.embedding_model
-    _provider = get_provider(_config.embedding_provider, **kwargs)
+    _provider = get_provider(_config.embedding_provider, **embedding_provider_kwargs(_config))
 
     await ensure_hnsw_index(_pg, _provider.dimension)
     logger.info("synapto MCP server ready (provider=%s, dim=%d)", _provider.name, _provider.dimension)
@@ -235,6 +232,12 @@ def _parse_memory_ids(memory_ids: list[str]) -> tuple[list[UUID], list[str]]:
 
 
 mcp = FastMCP("synapto", instructions=SERVER_INSTRUCTIONS, lifespan=_lifespan)
+
+
+@mcp.tool
+async def ping() -> str:
+    """Lightweight transport health check that does not touch databases, cache, or embeddings."""
+    return "pong"
 
 
 @mcp.prompt(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,69 @@
+"""Unit tests for Synapto configuration loading."""
+
+from __future__ import annotations
+
+import tomllib
+
+from synapto.config import SynaptoConfig, embedding_provider_kwargs, load_config, save_default_config
+
+
+def test_load_config_reads_embedding_device_from_env(monkeypatch):
+    monkeypatch.setenv("SYNAPTO_EMBEDDING_DEVICE", "cpu")
+
+    config = load_config()
+
+    assert config.embedding_device == "cpu"
+
+
+def test_load_config_reads_embedding_device_from_toml(tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("""
+[embeddings]
+provider = "sentence-transformers"
+model = "custom-model"
+device = "cpu"
+""")
+
+    config = load_config(config_path)
+
+    assert config.embedding_device == "cpu"
+
+
+def test_embedding_device_env_overrides_toml(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text("""
+[embeddings]
+device = "mps"
+""")
+    monkeypatch.setenv("SYNAPTO_EMBEDDING_DEVICE", "cpu")
+
+    config = load_config(config_path)
+
+    assert config.embedding_device == "cpu"
+
+
+def test_embedding_provider_kwargs_includes_configured_model_and_device():
+    config = SynaptoConfig(
+        embedding_model="custom-model",
+        embedding_device="cpu",
+    )
+
+    assert embedding_provider_kwargs(config) == {
+        "model_name": "custom-model",
+        "device": "cpu",
+    }
+
+
+def test_embedding_provider_kwargs_omits_unset_values():
+    assert embedding_provider_kwargs(SynaptoConfig()) == {}
+
+
+def test_save_default_config_writes_embedding_device(tmp_path, monkeypatch):
+    config_file = tmp_path / "config.toml"
+    monkeypatch.setattr("synapto.config.CONFIG_DIR", tmp_path)
+    monkeypatch.setattr("synapto.config.CONFIG_FILE", config_file)
+
+    save_default_config()
+
+    data = tomllib.loads(config_file.read_text())
+    assert data["embeddings"]["device"] == ""

--- a/tests/unit/test_embeddings.py
+++ b/tests/unit/test_embeddings.py
@@ -21,10 +21,16 @@ class FakeSentenceTransformerModel:
     def get_embedding_dimension(self) -> int:
         return 384
 
-    def encode(self, texts: list[str], normalize_embeddings: bool) -> list[FakeVector]:
+    def encode(
+        self,
+        texts: list[str],
+        normalize_embeddings: bool,
+        show_progress_bar: bool,
+    ) -> list[FakeVector]:
         self.encode_calls.append({
             "texts": texts,
             "normalize_embeddings": normalize_embeddings,
+            "show_progress_bar": show_progress_bar,
         })
         return [_fake_vector(text) for text in texts]
 
@@ -49,7 +55,8 @@ def _fake_vector(text: str) -> FakeVector:
 def fake_sentence_transformer_model(monkeypatch):
     model = FakeSentenceTransformerModel()
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.setattr("synapto.embeddings.sentence_transformer._load_model", lambda _model_name: model)
+    monkeypatch.delenv("SYNAPTO_EMBEDDING_DEVICE", raising=False)
+    monkeypatch.setattr("synapto.embeddings.sentence_transformer._load_model", lambda _model_name, _device: model)
     return model
 
 
@@ -80,7 +87,20 @@ class TestSentenceTransformerProvider:
         assert fake_sentence_transformer_model.encode_calls == [{
             "texts": ["hello world"],
             "normalize_embeddings": True,
+            "show_progress_bar": False,
         }]
+
+    def test_uses_explicit_device(self):
+        provider = SentenceTransformerProvider(device="cpu")
+
+        assert provider.device == "cpu"
+
+    def test_uses_environment_device(self, monkeypatch):
+        monkeypatch.setenv("SYNAPTO_EMBEDDING_DEVICE", "cpu")
+
+        provider = SentenceTransformerProvider()
+
+        assert provider.device == "cpu"
 
     def test_dimension_is_384(self, provider):
         assert provider.dimension == 384
@@ -112,6 +132,26 @@ class TestRegistry:
     def test_get_provider_by_name(self):
         provider = get_provider("sentence-transformers")
         assert isinstance(provider, SentenceTransformerProvider)
+
+    def test_get_provider_forwards_device(self):
+        provider = get_provider("sentence-transformers", device="cpu")
+
+        assert isinstance(provider, SentenceTransformerProvider)
+        assert provider.device == "cpu"
+
+    def test_get_openai_provider_drops_sentence_transformer_device(self, monkeypatch):
+        class FakeOpenAIProvider:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        monkeypatch.setattr(
+            "synapto.embeddings.openai_provider.OpenAIProvider",
+            FakeOpenAIProvider,
+        )
+
+        provider = get_provider("openai", model_name="text-embedding-3-small", device="cpu")
+
+        assert provider.kwargs == {"model": "text-embedding-3-small"}
 
     def test_get_provider_unknown_raises(self):
         with pytest.raises(ValueError, match="unknown"):

--- a/tests/unit/test_server_instructions.py
+++ b/tests/unit/test_server_instructions.py
@@ -12,8 +12,17 @@ def test_server_instructions_constant_is_non_empty():
 
 def test_server_instructions_mention_core_tools():
     """Instructions must reference the main tools so the LLM knows when to use them."""
-    for tool in ("recall", "remember"):
+    for tool in ("recall", "remember", "ping"):
         assert tool in SERVER_INSTRUCTIONS, f"instructions should mention {tool!r}"
+
+
+def test_server_instructions_guide_transport_health_checks():
+    for phrase in (
+        "transport health",
+        "does not touch PostgreSQL, Redis, or embeddings",
+        "Transport closed",
+    ):
+        assert phrase in SERVER_INSTRUCTIONS
 
 
 def test_server_instructions_cover_depth_layers():

--- a/tests/unit/test_tool_metadata.py
+++ b/tests/unit/test_tool_metadata.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from synapto.server import ALWAYS_LOAD_META, mcp
+from synapto.server import ALWAYS_LOAD_META, mcp, ping
 
 ALWAYS_LOAD_TOOLS = ("remember", "recall")
 DEFERRED_TOOLS = (
@@ -17,6 +17,7 @@ DEFERRED_TOOLS = (
     "update_memory",
     "agent_handoff_template",
     "handoff_inbox_template",
+    "ping",
     "graph_query",
     "list_entities_tool",
     "memory_stats",
@@ -96,3 +97,15 @@ async def test_recall_description_guides_proactive_context_loading():
         "Follow up with get_memory",
     ):
         assert phrase in recall.description
+
+
+async def test_ping_tool_is_lightweight_health_check():
+    ping = await mcp.get_tool("ping")
+
+    assert ping.meta is None
+    assert "transport health" in ping.description
+    assert "does not touch databases, cache, or embeddings" in ping.description
+
+
+async def test_ping_returns_pong_without_dependencies():
+    assert await ping() == "pong"


### PR DESCRIPTION
## Summary
- add lightweight MCP `ping` tool for transport health checks without touching PostgreSQL, Redis, or embeddings
- add `SYNAPTO_EMBEDDING_DEVICE` / `[embeddings].device` support for sentence-transformers so long-running agent sessions can force CPU and avoid noisy MPS/torch shutdown behavior
- disable sentence-transformers encode progress bars to keep MCP stdio logs clean
- centralize embedding model/device provider kwargs across MCP server and CLI paths
- document the transport diagnostic flow and add an Unreleased changelog entry for 0.5.1

## Context
Diagnostic source: `/Users/ramonramos/Documents/Codex/diagnostics/synapto-mcp-transport-findings-2026-07-01.md`

The underlying stale transport lifecycle likely needs MCP client recovery, but this reduces Synapto-side shutdown/log noise and gives Codex/Claude a cheap health check that can distinguish a live MCP connection from storage/search/provider failures.

## Validation
- `git diff --check`
- `uv run ruff check src/ tests/`
- `uv run pytest tests/unit/test_embeddings.py tests/unit/test_config.py tests/unit/test_tool_metadata.py tests/unit/test_server_instructions.py -q` (51 passed)
- `uv run pytest tests/unit -q` (256 passed)
- `uv run pytest tests/ -q` (256 passed)
- `uv run bandit -r src/synapto/ -c pyproject.toml`
- `uv run pip-audit --ignore-vuln CVE-2025-3000`
- `uv run python -m build`
- `uv run python -c 'import asyncio; from synapto.server import ping; print(asyncio.run(ping()))'` -> pong\n\n## Release\n- Intended for v0.5.1. Version remains 0.5.0 in this PR; release prep should bump to 0.5.1 after this fix merges.\n