### PR TITLE
docs: include MCP transport fix in 0.5.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
-### Fixed
-
-- **MCP stdio transport friendliness for long-running agent sessions** by adding a lightweight `ping` health tool, allowing sentence-transformers device override via `SYNAPTO_EMBEDDING_DEVICE` / `[embeddings].device`, disabling sentence-transformers encode progress bars, and ensuring CLI/MCP embedding provider paths share the same model/device configuration.
-
 ## [0.5.0] - 2026-07-01
 
 ### Added
@@ -24,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **MCP stdio transport friendliness for long-running agent sessions** by adding a lightweight `ping` health tool, allowing sentence-transformers device override via `SYNAPTO_EMBEDDING_DEVICE` / `[embeddings].device`, disabling sentence-transformers encode progress bars, and ensuring CLI/MCP embedding provider paths share the same model/device configuration.
 - **embedding tests now run offline and deterministically**, avoiding Hugging Face/cache network flakes in CI while still exercising the embedding integration surface (#59).
 
 ## [0.4.0] - 2026-06-10


### PR DESCRIPTION
## Summary
- move the MCP transport fix changelog entry from `Unreleased` into `0.5.0`
- keep version at 0.5.0 so the unpublished release includes the fix from PR #62

## Validation
- `git diff --check`

## Release
- After merge, publish v0.5.0 with `bump_type=current`.
