### PR TITLE
feat(memory): add domain-scoped memory contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **domain-scoped memory contract** (#45, #46, #47 foundation): memories gain a first-class nullable `domain` column (skill/repo/language bounded context) with a partial `(tenant, domain)` index. `MemoryRepository.create` persists domain; hybrid and vector search accept an injection-safe `domain` filter; `get_memory`/`get_memories`/`recall` output renders `domain` when set; CLI `search --domain`, `export`, and `import` preserve the field. Existing memories without domain keep working; MCP tool input parameters are unchanged (exposed in a follow-up PR).
+
 ## [0.5.0] - 2026-07-01
 
 ### Added

--- a/migrations/005_add_memory_domain.sql
+++ b/migrations/005_add_memory_domain.sql
@@ -1,0 +1,12 @@
+-- migrate:up
+
+ALTER TABLE memories ADD COLUMN IF NOT EXISTS domain VARCHAR(50);
+
+CREATE INDEX IF NOT EXISTS idx_memories_tenant_domain
+    ON memories (tenant, domain)
+    WHERE deleted_at IS NULL AND domain IS NOT NULL;
+
+-- migrate:down
+
+DROP INDEX IF EXISTS idx_memories_tenant_domain;
+ALTER TABLE memories DROP COLUMN IF EXISTS domain;

--- a/src/synapto/cli.py
+++ b/src/synapto/cli.py
@@ -205,7 +205,8 @@ def configure_mcp(client: str, tenant: str | None, yes: bool, home: str | None) 
 @click.option("--tenant", "-t", default=None, help="tenant/project scope")
 @click.option("--limit", "-n", default=10, help="max results")
 @click.option("--depth", "-d", default=None, help="depth layer filter")
-def search(query: str, tenant: str | None, limit: int, depth: str | None) -> None:
+@click.option("--domain", default=None, help="domain filter (skill/repo/language bounded context)")
+def search(query: str, tenant: str | None, limit: int, depth: str | None, domain: str | None) -> None:
     """Search memories from the command line."""
 
     async def _search():
@@ -225,7 +226,7 @@ def search(query: str, tenant: str | None, limit: int, depth: str | None) -> Non
         await ensure_hnsw_index(client, provider.dimension)
 
         results = await hybrid_search(
-            client, provider, query, tenant=t, depth_layer=depth, limit=limit
+            client, provider, query, tenant=t, depth_layer=depth, domain=domain, limit=limit
         )
 
         if not results:
@@ -505,7 +506,7 @@ def export_cmd(tenant: str | None, output: str) -> None:
         t = tenant or config.default_tenant
         rows = await client.execute(
             """
-            SELECT id, content, summary, type, subtype, tenant, depth_layer, metadata, created_at, accessed_at
+            SELECT id, content, summary, type, subtype, domain, tenant, depth_layer, metadata, created_at, accessed_at
             FROM memories WHERE deleted_at IS NULL AND tenant = %s ORDER BY created_at;
             """,
             (t,),
@@ -573,8 +574,8 @@ def import_cmd(file_path: str, tenant: str | None, fmt: str) -> None:
             await client.execute(
                 """
                 INSERT INTO memories
-                    (content, summary, embedding, embedding_dim, type, subtype, tenant, depth_layer, metadata)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s);
+                    (content, summary, embedding, embedding_dim, type, subtype, domain, tenant, depth_layer, metadata)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
                 """,
                 (
                     content,
@@ -583,6 +584,7 @@ def import_cmd(file_path: str, tenant: str | None, fmt: str) -> None:
                     provider.dimension,
                     item.get("type", "general"),
                     item.get("subtype"),
+                    item.get("domain"),
                     t,
                     item.get("depth_layer", "stable"),
                     Jsonb(item.get("metadata", {})),
@@ -821,8 +823,8 @@ def migrate_memories(dry_run: bool, home: str | None) -> None:
                                 """
                                 INSERT INTO memories
                                     (content, summary, embedding, embedding_dim,
-                                     type, subtype, tenant, depth_layer, metadata)
-                                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s);
+                                     type, subtype, domain, tenant, depth_layer, metadata)
+                                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
                                 """,
                                 (
                                     mem.content,
@@ -830,6 +832,7 @@ def migrate_memories(dry_run: bool, home: str | None) -> None:
                                     embedding,
                                     provider.dimension,
                                     mem.memory_type,
+                                    None,
                                     None,
                                     config.default_tenant,
                                     mem.depth_layer,

--- a/src/synapto/repositories/memories.py
+++ b/src/synapto/repositories/memories.py
@@ -18,10 +18,11 @@ from synapto.db.postgres import PostgresClient
 # ---------------------------------------------------------------------------
 
 _INSERT = """
-    INSERT INTO memories (content, summary, embedding, embedding_dim, type, subtype, tenant, depth_layer, metadata)
+    INSERT INTO memories
+        (content, summary, embedding, embedding_dim, type, subtype, domain, tenant, depth_layer, metadata)
     VALUES (
         %(content)s, %(summary)s, %(emb)s, %(dim)s, %(type)s, %(subtype)s,
-        %(tenant)s, %(depth)s, %(meta)s
+        %(domain)s, %(tenant)s, %(depth)s, %(meta)s
     )
     RETURNING id;
 """
@@ -33,6 +34,7 @@ _GET_BY_ID = """
         summary,
         type,
         subtype,
+        domain,
         tenant,
         depth_layer,
         metadata,
@@ -52,6 +54,7 @@ _GET_BY_IDS = """
         summary,
         type,
         subtype,
+        domain,
         tenant,
         depth_layer,
         metadata,
@@ -85,6 +88,7 @@ _UPDATE_MEMORY = """
         summary,
         type,
         subtype,
+        domain,
         tenant,
         depth_layer,
         metadata,
@@ -194,6 +198,7 @@ class MemoryRepository:
         tenant: str,
         depth_layer: str,
         subtype: str | None = None,
+        domain: str | None = None,
         summary: str | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> UUID:
@@ -206,6 +211,7 @@ class MemoryRepository:
                 "dim": embedding_dim,
                 "type": memory_type,
                 "subtype": subtype,
+                "domain": domain,
                 "tenant": tenant,
                 "depth": depth_layer,
                 "meta": Jsonb(metadata or {}),

--- a/src/synapto/search/hybrid.py
+++ b/src/synapto/search/hybrid.py
@@ -60,6 +60,7 @@ SELECT
     m.summary,
     m.type,
     m.subtype,
+    m.domain,
     m.tenant,
     m.depth_layer,
     m.decay_score,
@@ -107,6 +108,7 @@ class SearchResult:
     access_count: int
     created_at: datetime
     accessed_at: datetime
+    domain: str | None = None
 
 
 def _compute_hrr_boost(query: str, hrr_vector: bytes | None, hrr_weight: float = 0.15) -> float:
@@ -133,6 +135,7 @@ def _build_memory_filters(
     *,
     depth_layer: str | None = None,
     subtype: str | None = None,
+    domain: str | None = None,
     indent: str,
 ) -> tuple[str, dict[str, str]]:
     """Build shared optional memory filters.
@@ -148,6 +151,9 @@ def _build_memory_filters(
     if subtype:
         filters.append("AND subtype = %(subtype)s")
         params["subtype"] = subtype
+    if domain:
+        filters.append("AND domain = %(domain)s")
+        params["domain"] = domain
     return f"\n{indent}".join(filters), params
 
 
@@ -158,6 +164,7 @@ async def hybrid_search(
     tenant: str = "default",
     depth_layer: str | None = None,
     subtype: str | None = None,
+    domain: str | None = None,
     limit: int = 10,
     rrf_k: int = 60,
 ) -> list[SearchResult]:
@@ -175,6 +182,7 @@ async def hybrid_search(
     filter_sql, filter_params = _build_memory_filters(
         depth_layer=depth_layer,
         subtype=subtype,
+        domain=domain,
         indent="      ",
     )
     params.update(filter_params)
@@ -204,6 +212,7 @@ async def hybrid_search(
             summary=row["summary"],
             type=row["type"],
             subtype=row.get("subtype"),
+            domain=row.get("domain"),
             tenant=row["tenant"],
             depth_layer=row["depth_layer"],
             decay_score=row["decay_score"],
@@ -220,7 +229,7 @@ async def hybrid_search(
 
 VECTOR_ONLY_TEMPLATE = """
 SELECT
-    id, content, summary, type, subtype, tenant, depth_layer, decay_score, trust_score, metadata,
+    id, content, summary, type, subtype, domain, tenant, depth_layer, decay_score, trust_score, metadata,
     access_count, created_at, accessed_at,
     1 - (embedding::vector({dim}) <=> %(embedding)s::vector({dim})) AS similarity
 FROM memories
@@ -239,6 +248,7 @@ async def vector_search(
     tenant: str = "default",
     depth_layer: str | None = None,
     subtype: str | None = None,
+    domain: str | None = None,
     limit: int = 10,
 ) -> list[SearchResult]:
     """Pure vector similarity search (no keyword component)."""
@@ -253,6 +263,7 @@ async def vector_search(
     filter_sql, filter_params = _build_memory_filters(
         depth_layer=depth_layer,
         subtype=subtype,
+        domain=domain,
         indent="  ",
     )
     params.update(filter_params)
@@ -268,6 +279,7 @@ async def vector_search(
             summary=row["summary"],
             type=row["type"],
             subtype=row.get("subtype"),
+            domain=row.get("domain"),
             tenant=row["tenant"],
             depth_layer=row["depth_layer"],
             decay_score=row["decay_score"],

--- a/src/synapto/server.py
+++ b/src/synapto/server.py
@@ -190,6 +190,12 @@ def _format_memory(
         f"id: {row['id']}",
         f"tenant: {row['tenant']}",
         f"type: {row['type']}",
+    ]
+    if row.get("subtype"):
+        lines.append(f"subtype: {row['subtype']}")
+    if row.get("domain"):
+        lines.append(f"domain: {row['domain']}")
+    lines += [
         f"depth_layer: {row['depth_layer']}",
         f"trust_score: {float(row.get('trust_score', 0.5)):.2f}",
         f"decay_score: {float(row.get('decay_score', 1.0)):.2f}",
@@ -197,8 +203,6 @@ def _format_memory(
         f"created_at: {_format_timestamp(row.get('created_at'))}",
         f"accessed_at: {_format_timestamp(row.get('accessed_at'))}",
     ]
-    if row.get("subtype"):
-        lines.insert(3, f"subtype: {row['subtype']}")
     if row.get("summary"):
         lines.append(f"summary: {row['summary']}")
     lines.append(f"metadata: {_format_json(row.get('metadata'))}")
@@ -611,10 +615,12 @@ async def recall(
             if len(r.content) > preview_chars:
                 preview += "..."
         type_label = r.type if not getattr(r, "subtype", None) else f"{r.type}/{r.subtype}"
+        domain = getattr(r, "domain", None)
+        domain_label = f" domain={domain}" if domain else ""
         memories.append(
             f"[{r.depth_layer}] ({type_label}) score={r.rrf_score:.4f} "
             f"decay={r.decay_score:.2f} trust={r.trust_score:.2f} "
-            f"tenant={r.tenant} created_at={_format_timestamp(r.created_at)}\n"
+            f"tenant={r.tenant}{domain_label} created_at={_format_timestamp(r.created_at)}\n"
             f"  {preview}\n"
             f"  id={r.id}"
         )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -247,3 +247,151 @@ class TestServeCommand:
 
         assert result.exit_code == 0
         assert calls == [{"show_banner": False}]
+
+
+class _FakeDbClient:
+    """Minimal PostgresClient stand-in capturing SQL calls."""
+
+    def __init__(self, rows=None):
+        self.rows = rows or []
+        self.calls = []
+
+    async def connect(self):
+        pass
+
+    async def close(self):
+        pass
+
+    async def execute(self, sql, params=None):
+        self.calls.append((sql, params))
+        return self.rows
+
+
+class _FakeProvider:
+    dimension = 3
+
+    async def embed_one(self, text):
+        return [0.0, 0.0, 0.0]
+
+
+def _patch_cli_db(monkeypatch, fake_client):
+    from types import SimpleNamespace
+
+    config = SimpleNamespace(pg_dsn="postgresql://fake", default_tenant="cli_test", embedding_provider="fake")
+    monkeypatch.setattr("synapto.config.load_config", lambda: config)
+    monkeypatch.setattr("synapto.config.embedding_provider_kwargs", lambda cfg: {})
+    monkeypatch.setattr("synapto.db.postgres.PostgresClient", lambda dsn: fake_client)
+    monkeypatch.setattr("synapto.embeddings.registry.get_provider", lambda name, **kw: _FakeProvider())
+
+    async def _noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr("synapto.db.migrations.ensure_hnsw_index", _noop)
+    monkeypatch.setattr("synapto.db.migrations.run_migrations", _noop)
+
+
+class TestDomainCliPlumbing:
+    def test_search_forwards_domain_filter(self, monkeypatch):
+        fake_client = _FakeDbClient()
+        _patch_cli_db(monkeypatch, fake_client)
+        captured = {}
+
+        async def fake_hybrid_search(client, provider, query, **kwargs):
+            captured.update(kwargs)
+            return []
+
+        monkeypatch.setattr("synapto.search.hybrid.hybrid_search", fake_hybrid_search)
+
+        result = CliRunner().invoke(main, ["search", "timeouts", "--domain", "python"])
+
+        assert result.exit_code == 0, result.output
+        assert captured["domain"] == "python"
+
+    def test_export_includes_domain_key(self, monkeypatch):
+        fake_client = _FakeDbClient(
+            rows=[
+                {
+                    "id": "00000000-0000-0000-0000-000000000001",
+                    "content": "fact",
+                    "summary": None,
+                    "type": "project",
+                    "subtype": None,
+                    "domain": "python",
+                    "tenant": "cli_test",
+                    "depth_layer": "stable",
+                    "metadata": {},
+                    "created_at": "2026-07-09",
+                    "accessed_at": "2026-07-09",
+                }
+            ]
+        )
+        _patch_cli_db(monkeypatch, fake_client)
+
+        result = CliRunner().invoke(main, ["export"])
+
+        assert result.exit_code == 0, result.output
+        select_sql = fake_client.calls[0][0]
+        assert "domain" in select_sql
+        assert json.loads(result.output)[0]["domain"] == "python"
+
+    def test_import_persists_domain_from_json(self, monkeypatch, tmp_path):
+        fake_client = _FakeDbClient()
+        _patch_cli_db(monkeypatch, fake_client)
+
+        payload = [{"content": "fact", "domain": "python", "subtype": "workflow"}]
+        source = tmp_path / "memories.json"
+        source.write_text(json.dumps(payload))
+
+        result = CliRunner().invoke(main, ["import", str(source)])
+
+        assert result.exit_code == 0, result.output
+        insert_sql, insert_params = fake_client.calls[0]
+        assert "domain" in insert_sql
+        # positional asserts guard against column/parameter misalignment in the 10-column INSERT
+        assert insert_params[5] == "workflow"
+        assert insert_params[6] == "python"
+
+    def test_import_defaults_domain_to_none_for_legacy_payloads(self, monkeypatch, tmp_path):
+        fake_client = _FakeDbClient()
+        _patch_cli_db(monkeypatch, fake_client)
+
+        source = tmp_path / "legacy.json"
+        source.write_text(json.dumps([{"content": "pre-domain memory"}]))
+
+        result = CliRunner().invoke(main, ["import", str(source)])
+
+        assert result.exit_code == 0, result.output
+        _, insert_params = fake_client.calls[0]
+        assert insert_params[6] is None
+
+    def test_export_import_round_trip_preserves_domain(self, monkeypatch, tmp_path):
+        base_row = {
+            "content": "fact",
+            "summary": None,
+            "type": "project",
+            "subtype": None,
+            "tenant": "cli_test",
+            "depth_layer": "stable",
+            "metadata": {},
+            "created_at": "2026-07-09",
+            "accessed_at": "2026-07-09",
+        }
+        export_client = _FakeDbClient(
+            rows=[
+                {"id": "00000000-0000-0000-0000-000000000001", "domain": "python", **base_row},
+                {"id": "00000000-0000-0000-0000-000000000002", "domain": None, **base_row},
+            ]
+        )
+        _patch_cli_db(monkeypatch, export_client)
+        exported = CliRunner().invoke(main, ["export"])
+        assert exported.exit_code == 0, exported.output
+
+        source = tmp_path / "round_trip.json"
+        source.write_text(exported.output)
+        import_client = _FakeDbClient()
+        _patch_cli_db(monkeypatch, import_client)
+
+        result = CliRunner().invoke(main, ["import", str(source)])
+
+        assert result.exit_code == 0, result.output
+        assert [params[6] for _, params in import_client.calls] == ["python", None]

--- a/tests/unit/test_memory_retrieval_tools.py
+++ b/tests/unit/test_memory_retrieval_tools.py
@@ -39,12 +39,21 @@ async def _cleanup(pg):
     await pg.execute("DELETE FROM entities WHERE tenant = %s;", (TENANT,))
 
 
-async def _insert_memory(pg, provider, content: str, *, summary: str | None = None, subtype: str | None = None):
+async def _insert_memory(
+    pg,
+    provider,
+    content: str,
+    *,
+    summary: str | None = None,
+    subtype: str | None = None,
+    domain: str | None = None,
+):
     emb = await provider.embed_one(content)
     row = await pg.execute_one(
         """
-        INSERT INTO memories (content, summary, embedding, embedding_dim, type, subtype, tenant, depth_layer, metadata)
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING id;
+        INSERT INTO memories
+            (content, summary, embedding, embedding_dim, type, subtype, domain, tenant, depth_layer, metadata)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING id;
         """,
         (
             content,
@@ -53,6 +62,7 @@ async def _insert_memory(pg, provider, content: str, *, summary: str | None = No
             provider.dimension,
             "reference",
             subtype,
+            domain,
             TENANT,
             "stable",
             Jsonb({"source": "test"}),
@@ -82,6 +92,73 @@ async def test_memory_repository_get_by_id_returns_full_record(pg, provider):
     assert row["metadata"] == {"source": "test"}
 
     await _cleanup(pg)
+
+
+async def test_memory_repository_get_by_id_returns_domain(pg, provider):
+    await run_migrations(pg)
+    await _cleanup(pg)
+    memory_id = await _insert_memory(pg, provider, "domain-scoped fact", domain="python")
+
+    row = await MemoryRepository(pg).get_by_id(memory_id)
+
+    assert row is not None
+    assert row["domain"] == "python"
+
+    await _cleanup(pg)
+
+
+async def test_memory_repository_create_persists_domain(pg, provider):
+    await run_migrations(pg)
+    await _cleanup(pg)
+    emb = await provider.embed_one("created with domain")
+
+    memory_id = await MemoryRepository(pg).create(
+        content="created with domain",
+        embedding=emb,
+        embedding_dim=provider.dimension,
+        memory_type="project",
+        tenant=TENANT,
+        depth_layer="stable",
+        domain="jerry-workday",
+    )
+
+    row = await MemoryRepository(pg).get_by_id(memory_id)
+    assert row is not None
+    assert row["domain"] == "jerry-workday"
+
+    await _cleanup(pg)
+
+
+def test_format_memory_renders_domain_after_subtype():
+    row = {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "tenant": TENANT,
+        "type": "reference",
+        "subtype": "documentation",
+        "domain": "python",
+        "depth_layer": "stable",
+        "content": "body",
+    }
+
+    output = server._format_memory(row)
+    lines = output.splitlines()
+
+    assert "domain: python" in lines
+    assert lines.index("domain: python") == lines.index("subtype: documentation") + 1
+
+
+def test_format_memory_omits_domain_when_unset():
+    row = {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "tenant": TENANT,
+        "type": "reference",
+        "depth_layer": "stable",
+        "content": "body",
+    }
+
+    output = server._format_memory(row)
+
+    assert "domain:" not in output
 
 
 async def test_memory_repository_update_merges_partial_fields(pg, provider):
@@ -330,3 +407,48 @@ async def test_recall_passes_subtype_filter_to_hybrid_search(monkeypatch):
     await server.recall("coding standards", subtype="code_style")
 
     assert captured["subtype"] == "code_style"
+
+
+def _search_result_stub(**overrides):
+    fields = {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "content": "domain-tagged content",
+        "type": "project",
+        "subtype": None,
+        "tenant": TENANT,
+        "depth_layer": "stable",
+        "decay_score": 1.0,
+        "trust_score": 0.5,
+        "rrf_score": 0.1,
+        "created_at": datetime(2026, 5, 5, tzinfo=UTC),
+    }
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
+
+
+async def test_recall_renders_domain_when_set(monkeypatch):
+    async def fake_hybrid_search(*args, **kwargs):
+        return [_search_result_stub(domain="python")]
+
+    monkeypatch.setattr(server, "_pg", object())
+    monkeypatch.setattr(server, "_provider", object())
+    monkeypatch.setattr(server, "_config", SimpleNamespace(default_tenant=TENANT))
+    monkeypatch.setattr(server, "hybrid_search", fake_hybrid_search)
+
+    output = await server.recall("anything")
+
+    assert "domain=python" in output
+
+
+async def test_recall_omits_domain_when_absent(monkeypatch):
+    async def fake_hybrid_search(*args, **kwargs):
+        return [_search_result_stub()]
+
+    monkeypatch.setattr(server, "_pg", object())
+    monkeypatch.setattr(server, "_provider", object())
+    monkeypatch.setattr(server, "_config", SimpleNamespace(default_tenant=TENANT))
+    monkeypatch.setattr(server, "hybrid_search", fake_hybrid_search)
+
+    output = await server.recall("anything")
+
+    assert "domain=" not in output

--- a/tests/unit/test_migrations.py
+++ b/tests/unit/test_migrations.py
@@ -178,3 +178,44 @@ class TestRunMigrationsCompat:
         for table in ("memories", "entities", "relations", "memory_entities"):
             rows = await pg.execute("SELECT tablename FROM pg_tables WHERE tablename = %s;", (table,))
             assert len(rows) == 1, f"table {table} not found"
+
+
+class TestDomainColumnMigration:
+    """Migration 005 — nullable domain column plus partial tenant/domain index."""
+
+    async def test_memories_has_nullable_domain_column(self, pg):
+        await run_migrations(pg)
+        rows = await pg.execute(
+            """
+            SELECT data_type, character_maximum_length, is_nullable
+            FROM information_schema.columns
+            WHERE table_name = 'memories' AND column_name = 'domain';
+            """
+        )
+        assert len(rows) == 1, "memories.domain column not found"
+        assert rows[0]["data_type"] == "character varying"
+        assert rows[0]["character_maximum_length"] == 50
+        assert rows[0]["is_nullable"] == "YES"
+
+    async def test_tenant_domain_partial_index_exists(self, pg):
+        await run_migrations(pg)
+        rows = await pg.execute("SELECT indexdef FROM pg_indexes WHERE indexname = 'idx_memories_tenant_domain';")
+        assert len(rows) == 1, "idx_memories_tenant_domain not found"
+        indexdef = rows[0]["indexdef"]
+        assert "(tenant, domain)" in indexdef
+        assert "deleted_at IS NULL" in indexdef
+        assert "domain IS NOT NULL" in indexdef
+
+    async def test_migrate_down_removes_domain_column_and_index(self, pg):
+        await run_migrations(pg)
+
+        await migrate_down(pg, target_version=4)
+        columns = await pg.execute(
+            "SELECT 1 FROM information_schema.columns WHERE table_name = 'memories' AND column_name = 'domain';"
+        )
+        indexes = await pg.execute("SELECT 1 FROM pg_indexes WHERE indexname = 'idx_memories_tenant_domain';")
+
+        # restore schema before asserting so a failure doesn't poison other tests
+        await run_migrations(pg)
+        assert columns == []
+        assert indexes == []

--- a/tests/unit/test_search_and_graph.py
+++ b/tests/unit/test_search_and_graph.py
@@ -41,15 +41,15 @@ async def pg(pg):
     await pg.execute("DELETE FROM entities WHERE tenant = %s;", (TENANT,))
 
 
-async def _insert_memory(pg, provider, content, depth_layer="working", mem_type="general", subtype=None):
+async def _insert_memory(pg, provider, content, depth_layer="working", mem_type="general", subtype=None, domain=None):
     """Helper to insert a memory with embedding."""
     emb = await provider.embed_one(content)
     row = await pg.execute_one(
         """
-        INSERT INTO memories (content, embedding, embedding_dim, type, subtype, tenant, depth_layer)
-        VALUES (%s, %s, %s, %s, %s, %s, %s) RETURNING id;
+        INSERT INTO memories (content, embedding, embedding_dim, type, subtype, domain, tenant, depth_layer)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s) RETURNING id;
         """,
-        (content, emb, provider.dimension, mem_type, subtype, TENANT, depth_layer),
+        (content, emb, provider.dimension, mem_type, subtype, domain, TENANT, depth_layer),
     )
     return row["id"]
 
@@ -101,6 +101,49 @@ class TestHybridSearch:
 
         assert results
         assert all(r.subtype == "workflow" for r in results)
+
+    async def test_domain_filter(self, pg, provider):
+        await ensure_hnsw_index(pg, provider.dimension)
+        await _insert_memory(
+            pg,
+            provider,
+            "async endpoints need explicit timeouts",
+            mem_type="project",
+            domain="python",
+        )
+        await _insert_memory(
+            pg,
+            provider,
+            "genserver restarts should be transient",
+            mem_type="project",
+            domain="elixir",
+        )
+
+        results = await hybrid_search(pg, provider, "explicit timeouts", tenant=TENANT, domain="python")
+
+        assert results
+        assert all(r.domain == "python" for r in results)
+
+    async def test_domain_none_returns_all_domains(self, pg, provider):
+        await ensure_hnsw_index(pg, provider.dimension)
+        await _insert_memory(pg, provider, "python fact about tooling", domain="python")
+        await _insert_memory(pg, provider, "elixir fact about tooling", domain="elixir")
+
+        results = await hybrid_search(pg, provider, "fact about tooling", tenant=TENANT, domain=None)
+        domains = {r.domain for r in results}
+        assert len(domains) >= 2
+
+    async def test_domain_filter_excludes_legacy_rows_without_domain(self, pg, provider):
+        await ensure_hnsw_index(pg, provider.dimension)
+        await _insert_memory(pg, provider, "legacy note about tooling")
+        await _insert_memory(pg, provider, "python note about tooling", domain="python")
+
+        unfiltered = await hybrid_search(pg, provider, "note about tooling", tenant=TENANT)
+        assert {r.domain for r in unfiltered} == {None, "python"}
+
+        filtered = await hybrid_search(pg, provider, "note about tooling", tenant=TENANT, domain="python")
+        assert filtered
+        assert all(r.domain == "python" for r in filtered)
 
 
 class TestHybridSearchParameterization:
@@ -167,6 +210,37 @@ class TestHybridSearchParameterization:
             "debug session",
             tenant=TENANT,
             subtype="workflow' OR '1'='1",
+        )
+        assert len(results) == 0
+
+    async def test_domain_with_special_characters(self, pg, provider):
+        """Ensure domain with SQL injection payload doesn't break or leak data."""
+        await ensure_hnsw_index(pg, provider.dimension)
+        await _insert_memory(pg, provider, "python note should not leak", domain="python")
+
+        results = await hybrid_search(
+            pg,
+            provider,
+            "python note",
+            tenant=TENANT,
+            domain="python' OR '1'='1",
+        )
+
+        assert len(results) == 0
+
+    async def test_vector_search_domain_parameterized(self, pg, provider):
+        await ensure_hnsw_index(pg, provider.dimension)
+        await _insert_memory(pg, provider, "python debug session", domain="python")
+
+        results = await vector_search(pg, provider, "debug session", tenant=TENANT, domain="python")
+        assert all(r.domain == "python" for r in results)
+
+        results = await vector_search(
+            pg,
+            provider,
+            "debug session",
+            tenant=TENANT,
+            domain="python' OR '1'='1",
         )
         assert len(results) == 0
 


### PR DESCRIPTION
## Summary

PR-1 of the v0.6.0 release plan (`synapto-v0.6.0-release-plan-2026-07-09`): makes `domain` a first-class, nullable memory field — the skill/repo/language **bounded context** axis (DDD ubiquitous language: Tenant = project scope, Domain = skill/repo/language context) — so the governed context layer can query it without JSONB guessing.

Supports #45 / #46 / #47.

## What changed

- **Migration `005_add_memory_domain.sql`** — nullable `domain VARCHAR(50)` on `memories` plus partial index `idx_memories_tenant_domain (tenant, domain) WHERE deleted_at IS NULL AND domain IS NOT NULL`, mirroring the `subtype` precedent (004). Composite `(tenant, domain, depth_layer)` indexes were evaluated and **not** added: every search WHERE clause filters `tenant` + independent optional predicates, so the two-column partial index covers the new query axis (Big-O gate).
- **Repository** — `MemoryRepository.create(domain=...)` persists it; `_GET_BY_ID`, `_GET_BY_IDS`, and `_UPDATE_MEMORY RETURNING` project it. All SQL stays parameterized (`%(domain)s`).
- **Search** — `hybrid_search` / `vector_search` accept an optional `domain` filter via the shared `_build_memory_filters` (O(1), injection-safe); `SearchResult` gains `domain: str | None = None` (defaulted — no positional breakage).
- **MCP output formatting** — `get_memory` / `get_memories` render a `domain:` line when set (`_format_memory` restructured from `lines.insert()` index math to conditional appends); `recall` headers append `domain=<x>` when present. **No MCP tool input parameters changed** — `remember`/`recall` gain the `domain` param in PR-2.
- **CLI** — `search --domain`, `export` (JSON key), `import` (`item.get("domain")`, legacy payloads without the key import as NULL), `migrate-memories` column alignment.

## Backward compatibility

Existing memories keep working with `domain` NULL; a `domain` filter excludes legacy rows by design (covered by test). Old export payloads import cleanly.

## Tests (TDD — written first, mutation-hardened)

- Migration up **and** down (column/index existence via `information_schema`/`pg_indexes`)
- Repository create/get round-trip for domain
- Hybrid + vector search: filter match, NULL-legacy exclusion, SQL-injection payloads return 0 rows
- Formatting: `domain:` line ordering after `subtype:`, absent when unset; recall `domain=` token present/absent (getattr-guarded)
- CLI: `--domain` forwarding, export→import round-trip (`["python", None]`), positional INSERT asserts (kills the subtype/domain swap mutant found in adversarial review)

`uv run pytest tests/ -q` → **275 passed** · `ruff check` clean · `bandit -r src` clean

## Known follow-ups (out of PR-1 scope)

- CLI `import` has no length guard for `domain` (>50 chars → `StringDataRightTruncation` mid-loop) — this exactly mirrors the pre-existing unvalidated `subtype` path; close both in PR-2's shared validation (`MAX_DOMAIN_CHARS`) or PR-5.
- `migrate-memories` INSERT has no direct test (pre-existing gap; alignment verified in review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)