### PR TITLE
feat(mcp): add domain-aware remember and recall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Added
 
 - **domain-scoped memory contract** (#45, #46, #47 foundation): memories gain a first-class nullable `domain` column (skill/repo/language bounded context) with a partial `(tenant, domain)` index. `MemoryRepository.create` persists domain; hybrid and vector search accept an injection-safe `domain` filter; `get_memory`/`get_memories`/`recall` output renders `domain` when set; CLI `search --domain`, `export`, and `import` preserve the field. Existing memories without domain keep working; MCP tool input parameters are unchanged (exposed in a follow-up PR).
+- **domain-aware `remember` and `recall` MCP tools** (#45, #46 foundation): both tools accept an optional `domain` parameter (validated, max 50 chars) so agents can store `domain=python` / `domain=jerry-workday` context and recall it by bounded context without semantic query guessing. Tool descriptions and server instructions now guide agents to route durable skill/domain knowledge into Synapto with `domain=`. `alwaysLoad` stays limited to `remember`/`recall`.
 
 ## [0.5.0] - 2026-07-01
 

--- a/src/synapto/prompts/server_instructions.md
+++ b/src/synapto/prompts/server_instructions.md
@@ -13,6 +13,9 @@ When to call `recall`:
 - When the user references past decisions, history, or preferences
   (e.g. "remember", "lembra", "do you know", "what do we know about").
 - Before creating PRs, commits, or deploys — to confirm workflow rules.
+- Pass `domain=` (skill/repo/language bounded context, e.g. `domain=python`,
+  `domain=jerry-workday`) to load only that domain's governed context without
+  semantic query guessing.
 
 When to call `remember`:
 - The user sets a rule ("always X", "never Y", "from now on") → feedback/core.
@@ -22,6 +25,10 @@ When to call `remember`:
 - The user mentions temporal context ("this sprint", "deadline") → project/working.
 - The user shares identity, role, or long-term preferences → user/stable.
 - The user references external systems ("tracked in Linear") → reference/stable.
+- Durable skill/repo/language knowledge (patterns, conventions, tooling rules
+  tied to one bounded context) → store with `domain=` (e.g. `domain=python`,
+  `domain=synapto`) so skills fetch governed context from Synapto instead of
+  flat files.
 
 When to call `relate` and `graph_query`:
 - After storing memories that reference named entities, create relations so the

--- a/src/synapto/server.py
+++ b/src/synapto/server.py
@@ -124,6 +124,7 @@ MAX_BULK_MEMORY_IDS = 20
 MAX_SUMMARY_CHARS = 255
 MAX_MEMORY_TYPE_CHARS = 20
 MAX_SUBTYPE_CHARS = 50
+MAX_DOMAIN_CHARS = 50
 MAX_TENANT_CHARS = 100
 MAX_DEPTH_LAYER_CHARS = 20
 RECALL_CONTENT_ELIDED = "[content elided - fetch full via get_memory(id)]"
@@ -162,12 +163,18 @@ def _validate_memory_fields(
     *,
     memory_type: str | None = None,
     subtype: str | None = None,
+    domain: str | None = None,
     tenant: str | None = None,
     depth_layer: str | None = None,
     summary: str | None = None,
 ) -> None:
     _validate_max_chars("memory_type", memory_type, MAX_MEMORY_TYPE_CHARS)
     _validate_max_chars("subtype", subtype, MAX_SUBTYPE_CHARS)
+    _validate_max_chars("domain", domain, MAX_DOMAIN_CHARS)
+    if domain is not None and not domain.strip():
+        # '' would persist as a non-NULL value that the truthiness-gated filter
+        # and output formatting can never match — reject instead of silently storing
+        raise ToolError("domain must not be empty or whitespace-only — omit it instead")
     _validate_max_chars("tenant", tenant, MAX_TENANT_CHARS)
     _validate_max_chars("depth_layer", depth_layer, MAX_DEPTH_LAYER_CHARS)
     _validate_max_chars(
@@ -364,6 +371,7 @@ async def remember(
     content: str,
     memory_type: str = "general",
     subtype: str | None = None,
+    domain: str | None = None,
     tenant: str | None = None,
     depth_layer: str = "working",
     summary: str | None = None,
@@ -397,6 +405,11 @@ async def remember(
     - project: working, stable, archived.
     - user: role, preference, skill, constraint.
 
+    Optional domain scopes a memory to a skill/repo/language bounded context
+    (for example python, elixir, synapto, jerry-workday). Store durable
+    skill/domain knowledge with a domain so recall can filter by domain instead
+    of guessing from the semantic query.
+
     Recommended depth_layer choices:
     - core: rules that should not expire, such as "always" or "never" feedback.
     - stable: context expected to last months, such as architecture decisions.
@@ -407,6 +420,7 @@ async def remember(
         content: memory content to store (text; no Synapto length limit)
         memory_type: category (general, user, feedback, project, reference; max 20 chars)
         subtype: optional free-form subcategory (recommended values documented; max 50 chars)
+        domain: optional skill/repo/language bounded context (max 50 chars)
         tenant: project/tenant scope (defaults to config default; max 100 chars)
         depth_layer: core, stable, working, or ephemeral (max 20 chars)
         summary: optional short summary (max 255 chars)
@@ -416,6 +430,7 @@ async def remember(
     _validate_memory_fields(
         memory_type=memory_type,
         subtype=subtype,
+        domain=domain,
         tenant=tenant,
         depth_layer=depth_layer,
         summary=summary,
@@ -434,6 +449,7 @@ async def remember(
         embedding_dim=provider.dimension,
         memory_type=memory_type,
         subtype=subtype,
+        domain=domain,
         tenant=t,
         depth_layer=depth_layer,
         summary=summary,
@@ -458,7 +474,7 @@ async def remember(
     cache = _get_cache()
     await cache.cache_memory(
         memory_id,
-        {"content": content, "type": memory_type, "subtype": subtype, "tenant": t},
+        {"content": content, "type": memory_type, "subtype": subtype, "domain": domain, "tenant": t},
     )
 
     entity_count = len(entity_names)
@@ -563,6 +579,7 @@ async def recall(
     tenant: str | None = None,
     depth_layer: str | None = None,
     subtype: str | None = None,
+    domain: str | None = None,
     limit: int = 10,
     preview_chars: int = DEFAULT_RECALL_PREVIEW_CHARS,
 ) -> str:
@@ -575,22 +592,25 @@ async def recall(
     waiting for the user to ask.
 
     Use tenant to scope project-specific memory, depth_layer to narrow by decay
-    semantics, and subtype to narrow within a memory_type, such as workflow or
-    code_style feedback. Follow up with get_memory when a recalled result needs
-    full content, metadata, or linked entities.
+    semantics, subtype to narrow within a memory_type, such as workflow or
+    code_style feedback, and domain to narrow to a skill/repo/language bounded context
+    (for example python or jerry-workday) without semantic query guessing.
+    Follow up with get_memory when a recalled result needs full content,
+    metadata, or linked entities.
 
     Args:
         query: natural language search query
         tenant: filter to a specific project/tenant
         depth_layer: filter to a specific depth layer (core, stable, working, ephemeral)
         subtype: optional memory subcategory filter (for example code_style or workflow)
+        domain: optional bounded-context filter (skill/repo/language; max 50 chars)
         limit: max results to return
         preview_chars: max content characters per result (0-1000)
     """
     pg = _get_pg()
     provider = _get_provider()
     t = tenant or _config.default_tenant
-    _validate_memory_fields(subtype=subtype)
+    _validate_memory_fields(subtype=subtype, domain=domain)
     preview_chars = max(0, min(preview_chars, MAX_RECALL_PREVIEW_CHARS))
 
     results = await hybrid_search(
@@ -600,6 +620,7 @@ async def recall(
         tenant=t,
         depth_layer=depth_layer,
         subtype=subtype,
+        domain=domain,
         limit=limit,
     )
 

--- a/tests/unit/test_memory_retrieval_tools.py
+++ b/tests/unit/test_memory_retrieval_tools.py
@@ -267,6 +267,81 @@ async def test_remember_rejects_overlong_summary_before_database_access():
         await server.remember("content", summary="x" * 256)
 
 
+async def test_remember_rejects_overlong_domain_before_database_access():
+    with pytest.raises(ToolError, match="domain exceeds 50 chars \\(got 51\\)"):
+        await server.remember("content", domain="x" * 51)
+
+
+async def test_remember_rejects_empty_domain_before_database_access():
+    with pytest.raises(ToolError, match="domain must not be empty"):
+        await server.remember("content", domain="")
+
+    with pytest.raises(ToolError, match="domain must not be empty"):
+        await server.remember("content", domain="   ")
+
+
+async def test_recall_rejects_overlong_domain(monkeypatch):
+    monkeypatch.setattr(server, "_pg", object())
+    monkeypatch.setattr(server, "_provider", object())
+    monkeypatch.setattr(server, "_config", SimpleNamespace(default_tenant=TENANT))
+
+    with pytest.raises(ToolError, match="domain exceeds 50 chars \\(got 51\\)"):
+        await server.recall("anything", domain="x" * 51)
+
+
+class _RecordingCache:
+    def __init__(self) -> None:
+        self.cached = []
+
+    async def cache_memory(self, memory_id, payload):
+        self.cached.append((memory_id, payload))
+
+
+async def test_remember_persists_domain(pg, provider, monkeypatch):
+    await run_migrations(pg)
+    await _cleanup(pg)
+    cache = _RecordingCache()
+    monkeypatch.setattr(server, "_pg", pg)
+    monkeypatch.setattr(server, "_provider", provider)
+    monkeypatch.setattr(server, "_cache", cache)
+    monkeypatch.setattr(server, "_config", SimpleNamespace(default_tenant=TENANT))
+
+    output = await server.remember(
+        "async endpoints need explicit timeouts",
+        memory_type="project",
+        domain="python",
+        extract_entities=False,
+    )
+
+    memory_id = output.split()[2]
+    row = await MemoryRepository(pg).get_by_id(memory_id)
+    assert row is not None
+    assert row["domain"] == "python"
+    assert cache.cached[0][1]["domain"] == "python"
+
+    await _cleanup(pg)
+
+
+async def test_remember_without_domain_stores_null(pg, provider, monkeypatch):
+    await run_migrations(pg)
+    await _cleanup(pg)
+    cache = _RecordingCache()
+    monkeypatch.setattr(server, "_pg", pg)
+    monkeypatch.setattr(server, "_provider", provider)
+    monkeypatch.setattr(server, "_cache", cache)
+    monkeypatch.setattr(server, "_config", SimpleNamespace(default_tenant=TENANT))
+
+    output = await server.remember("plain memory without domain", extract_entities=False)
+
+    memory_id = output.split()[2]
+    row = await MemoryRepository(pg).get_by_id(memory_id)
+    assert row is not None
+    assert row["domain"] is None
+    assert cache.cached[0][1]["domain"] is None
+
+    await _cleanup(pg)
+
+
 async def test_update_memory_rejects_overlong_summary_before_database_access():
     with pytest.raises(ToolError, match="summary exceeds 255 chars \\(got 256\\)"):
         await server.update_memory("00000000-0000-0000-0000-000000000000", summary="x" * 256)
@@ -407,6 +482,26 @@ async def test_recall_passes_subtype_filter_to_hybrid_search(monkeypatch):
     await server.recall("coding standards", subtype="code_style")
 
     assert captured["subtype"] == "code_style"
+    # omitted domain must forward as None — the truthiness gate in hybrid_search
+    # relies on it to skip the filter
+    assert captured["domain"] is None
+
+
+async def test_recall_passes_domain_filter_to_hybrid_search(monkeypatch):
+    captured = {}
+
+    async def fake_hybrid_search(*args, **kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(server, "_pg", object())
+    monkeypatch.setattr(server, "_provider", object())
+    monkeypatch.setattr(server, "_config", SimpleNamespace(default_tenant=TENANT))
+    monkeypatch.setattr(server, "hybrid_search", fake_hybrid_search)
+
+    await server.recall("async patterns", domain="python")
+
+    assert captured["domain"] == "python"
 
 
 def _search_result_stub(**overrides):

--- a/tests/unit/test_server_instructions.py
+++ b/tests/unit/test_server_instructions.py
@@ -43,3 +43,8 @@ def test_server_instructions_cover_handoffs():
 def test_fastmcp_instance_has_instructions_attached():
     """The FastMCP instance must expose the instructions so MCP clients can inject them."""
     assert mcp.instructions == SERVER_INSTRUCTIONS
+
+
+def test_server_instructions_cover_domain_scoping():
+    for phrase in ("domain", "bounded context", "domain="):
+        assert phrase in SERVER_INSTRUCTIONS, f"instructions should mention {phrase!r}"

--- a/tests/unit/test_tool_metadata.py
+++ b/tests/unit/test_tool_metadata.py
@@ -109,3 +109,31 @@ async def test_ping_tool_is_lightweight_health_check():
 
 async def test_ping_returns_pong_without_dependencies():
     assert await ping() == "pong"
+
+
+async def test_remember_description_documents_domain_bounded_context():
+    remember = await mcp.get_tool("remember")
+
+    for phrase in (
+        "domain: optional skill/repo/language bounded context (max 50 chars)",
+        "jerry-workday",
+        "recall can filter by domain",
+    ):
+        assert phrase in remember.description
+
+
+async def test_recall_description_documents_domain_filter():
+    recall = await mcp.get_tool("recall")
+
+    for phrase in (
+        "domain to narrow to a skill/repo/language bounded context",
+        "domain: optional bounded-context filter (skill/repo/language; max 50 chars)",
+    ):
+        assert phrase in recall.description
+
+
+async def test_domain_parameter_exposed_in_tool_input_schemas():
+    """MCP clients must see 'domain' in the remember/recall input schemas."""
+    for name in ("remember", "recall"):
+        tool = await mcp.get_tool(name)
+        assert "domain" in tool.parameters["properties"], f"{name!r} must expose a domain input parameter"


### PR DESCRIPTION
## Summary

PR-2 of the v0.6.0 release plan (`synapto-v0.6.0-release-plan-2026-07-09`), **stacked on #64** (base branch: `feat/domain-scoped-memory-contract` — retarget to `main` after #64 merges). Exposes the domain contract from PR-1 on the MCP surface so Claude/Codex can store `domain=python` / `domain=synapto` / `domain=jerry-workday` context and recall it by bounded context without semantic query guessing.

Supports #45, foundation for #46.

## What changed

- **`remember(domain=...)`** — optional param, validated via the shared `_validate_memory_fields` (new `MAX_DOMAIN_CHARS = 50`), persisted through `MemoryRepository.create` and included in the Redis cache payload. Docstring documents the bounded-context language and examples.
- **`recall(domain=...)`** — optional filter, validated, forwarded to `hybrid_search`; omitted domain forwards as `None` (no spurious filter). Output already renders `domain=` from PR-1.
- **Empty-string guard** — `domain=""`/whitespace-only is rejected with a clear ToolError instead of silently persisting a non-NULL value that the truthiness-gated filter and formatting could never match (NULL-vs-`''` contract mismatch caught in adversarial review).
- **Tool descriptions + `server_instructions.md`** — guide agents to route durable skill/repo/language knowledge into Synapto with `domain=` and to filter recall by domain. `alwaysLoad` unchanged (remember/recall only).

## Tests (TDD — 7 written first, +4 from adversarial review)

- Validation: overlong (>50) and empty/whitespace domain rejected before DB access, on both tools
- E2E: `remember` persists domain + caches it; `remember` **without** domain stores NULL and caches `None` (regression guard for the changed cache payload)
- Forwarding: `recall` passes `domain` to `hybrid_search`; omitted domain forwards as `None`
- Metadata: description phrases for both tools + **inputSchema-level** assert that `domain` appears in `remember`/`recall` tool parameters
- Instructions: `domain=` routing guidance present in `SERVER_INSTRUCTIONS`

`uv run pytest tests/ -q` → **285 passed** · `ruff check` clean · `bandit -r src` clean

## Acceptance (from the release plan)

- ✅ store `domain=python|synapto|jerry-workday` via MCP remember
- ✅ recall filters by domain without semantic query guessing
- ✅ output includes id, tenant, domain, type/subtype, depth, provenance
- ✅ no new alwaysLoad tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)